### PR TITLE
Clarify process queue

### DIFF
--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -315,6 +315,7 @@ def get_active_completed_scan_reports(api_url, headers):
 def post_paginated_concepts(concepts_to_post, api_url, headers):
     paginated_concepts_to_post = paginate(concepts_to_post)
     concept_response = []
+    concept_response_content = []
     for concepts_to_post_item in paginated_concepts_to_post:
         post_concept_response = requests.post(
             url=api_url + "scanreportconcepts/",
@@ -527,7 +528,6 @@ def reuse_existing_field_concepts(new_fields_map, content_type, api_url, headers
 
     logger.debug(f"{existing_field_name_to_field_and_concept_id_map=}")
     concepts_to_post = []
-    concept_response_content = []
     logger.debug(f"{new_fields_map=}")
     logger.debug(f"{existing_field_id_to_concept_map=}")
     # print("NAME IDS", new_fields_map.keys())
@@ -813,7 +813,6 @@ def reuse_existing_value_concepts(new_values_map, content_type, api_url, headers
             ] = (str(next(target_value_id)), str(target_concept_ids.pop()))
 
     concepts_to_post = []
-    concept_response_content = []
     for new_value_detail in new_values_full_details:
         try:
             existing_value_id, concept_id = value_details_to_value_and_concept_id_map[

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -300,6 +300,32 @@ def flatten(arr):
     return newArr
 
 
+def get_active_completed_scan_reports(api_url, headers):
+    # TODO: could this be replaced by a single API endpoint?
+    # get all scan reports to be used to filter values by only values that come from
+    # active scan reports that are marked as 'Mapping Complete'
+    get_scan_reports = requests.get(
+        url=f"{api_url}scanreports/",
+        headers=headers,
+    )
+    get_datasets = requests.get(
+        url=f"{api_url}datasets/",
+        headers=headers,
+    )
+    # get active scanreports and map them to fields. Remove any fields in archived
+    # reports or not marked as 'Mapping Complete'
+    active_srs = []
+    for item in get_scan_reports.json():
+        if item["hidden"] is False and item["status"] == "COMPLET":
+            for ds in get_datasets.json():
+                # Exclude scan reports if their parent_dataset is archived
+                if ds["id"] == item["parent_dataset"] and ds["hidden"] is False:
+                    active_srs.append(str(item["id"]))
+    # active reports is list of report ids that belong to an active dataset, are not archived, and have the status
+    # 'Mapping Complete'
+    return active_srs
+
+
 def reuse_existing_field_concepts(new_fields_map, content_type, api_url, headers):
     """
     This expects a dict of field names to ids which have been generated in a newly uploaded
@@ -396,26 +422,8 @@ def reuse_existing_field_concepts(new_fields_map, content_type, api_url, headers
         )
     existing_tables_details = flatten(existing_tables_details)
 
-    # get all scan reports to be used to filter values by only values that come from
-    # active scan reports that are marked as 'Mapping Complete'
-    get_scan_reports = requests.get(
-        url=f"{api_url}scanreports/",
-        headers=headers,
-    )
-    get_datasets = requests.get(
-        url=f"{api_url}datasets/",
-        headers=headers,
-    )
-    # get active scanreports and map them to fields. Remove any fields in archived
-    # reports or not marked as 'Mapping Complete'
-    active_srs = []
-    for item in get_scan_reports.json():
-        if item["hidden"] is False and item["status"] == "COMPLET":
-            for ds in get_datasets.json():
-                # Exclude scan reports if their parent_dataset is archived
-                if ds["id"] == item["parent_dataset"] and ds["hidden"] is False:
-                    active_srs.append(str(item["id"]))
-    # active reports is list of report ids that belong to an active dataset, are not archived, and have the status
+    active_srs = get_active_completed_scan_reports(api_url, headers)
+    # active_srs is list of report ids that belong to an active dataset, are not archived, and have the status
     # 'Mapping Complete'
 
     # map value id to active scan report
@@ -691,26 +699,8 @@ def reuse_existing_value_concepts(new_values_map, content_type, api_url, headers
         )
     existing_tables_details = flatten(existing_tables_details)
 
-    # get all scan reports to be used to filter values by only values that come from
-    # active scan reports that are marked as 'Mapping Complete'
-    get_scan_reports = requests.get(
-        url=f"{api_url}scanreports/",
-        headers=headers,
-    )
-    get_datasets = requests.get(
-        url=f"{api_url}datasets/",
-        headers=headers,
-    )
-    # get active scanreports and map them to fields. Remove any fields in archived
-    # reports or not marked as 'Mapping Complete'
-    active_srs = []
-    for item in get_scan_reports.json():
-        if item["hidden"] is False and item["status"] == "COMPLET":
-            for ds in get_datasets.json():
-                # Exclude scan reports if their parent_dataset is archived
-                if ds["id"] == item["parent_dataset"] and ds["hidden"] is False:
-                    active_srs.append(str(item["id"]))
-    # active reports is list of report ids that belong to an active dataset, are not archived, and have the status
+    active_srs = get_active_completed_scan_reports(api_url, headers)
+    # active_srs is list of report ids that belong to an active dataset, are not archived, and have the status
     # 'Mapping Complete'
 
     # map value id to active scan report

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -314,13 +314,13 @@ def get_active_completed_scan_reports(api_url, headers):
     )
     # get active scanreports and map them to fields. Remove any fields in archived
     # reports or not marked as 'Mapping Complete'
-    active_srs = []
-    for item in get_scan_reports.json():
-        if item["hidden"] is False and item["status"] == "COMPLET":
-            for ds in get_datasets.json():
-                # Exclude scan reports if their parent_dataset is archived
-                if ds["id"] == item["parent_dataset"] and ds["hidden"] is False:
-                    active_srs.append(str(item["id"]))
+    get_active_completed_srs = requests.get(
+        url=f"{api_url}scanreportfilter/?status=COMPLET&hidden"
+        f"=false&parent_dataset__hidden=false",
+        headers=headers,
+    )
+    active_srs = [str(item["id"]) for item in get_active_completed_srs.json()]
+
     # active reports is list of report ids that belong to an active dataset, are not archived, and have the status
     # 'Mapping Complete'
     return active_srs

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -1478,7 +1478,7 @@ def main(msg: func.QueueMessage):
     # This is the same as looping over all fields in all tables.
     # When the end of one table is reached, then post all the ScanReportFields
     # and ScanReportValues associated to that table, then continue down the
-    # list of fields in tables until all fields in all tables have been 
+    # list of fields in tables until all fields in all tables have been
     # processed (along with their ScanReportValues).
     process_all_fields_and_values(
         fo_ws,

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -302,28 +302,14 @@ def flatten(arr):
 
 def get_active_completed_scan_reports(api_url, headers):
     # TODO: could this be replaced by a single API endpoint?
-    # get all scan reports to be used to filter values by only values that come from
-    # active scan reports that are marked as 'Mapping Complete'
-    get_scan_reports = requests.get(
-        url=f"{api_url}scanreports/",
-        headers=headers,
-    )
-    get_datasets = requests.get(
-        url=f"{api_url}datasets/",
-        headers=headers,
-    )
-    # get active scanreports and map them to fields. Remove any fields in archived
-    # reports or not marked as 'Mapping Complete'
+    # get all scan reports that are not hidden, do not live in a hidden Dataset,
+    # and are marked as 'Mapping Complete'
     get_active_completed_srs = requests.get(
         url=f"{api_url}scanreportfilter/?status=COMPLET&hidden"
         f"=false&parent_dataset__hidden=false",
         headers=headers,
     )
-    active_srs = [str(item["id"]) for item in get_active_completed_srs.json()]
-
-    # active reports is list of report ids that belong to an active dataset, are not archived, and have the status
-    # 'Mapping Complete'
-    return active_srs
+    return [str(item["id"]) for item in get_active_completed_srs.json()]
 
 
 def post_paginated_concepts(concepts_to_post, api_url, headers):

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -285,12 +285,7 @@ def process_failure(api_url, scan_report_id, headers):
         scan_report_fetched_data.content.decode("utf-8")
     )
 
-    json_data = json.dumps(
-        {
-            "dataset": f"FAILED: {scan_report_fetched_data['dataset']}",
-            "status": "UPFAILE",
-        }
-    )
+    json_data = json.dumps({"status": "UPFAILE"})
 
     failure_response = requests.patch(
         url=f"{api_url}scanreports/{scan_report_id}/", data=json_data, headers=headers

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -905,21 +905,25 @@ def post_field_entries(field_entries_to_post, scan_report_id):
     return fields_response_content
 
 
-def post_table_entries(current_table_name, field_entries_to_post, scan_report_id, wb, data_dictionary, vocab_dictionary):
+def post_table_entries(
+    current_table_name,
+    field_entries_to_post,
+    scan_report_id,
+    wb,
+    data_dictionary,
+    vocab_dictionary,
+):
     # This is the scenario where the line is empty, so we're at the end of
     # the table. Don't add a field entry, but process all those so far.
     # print("scan_report_field_entries >>>", field_entries_to_post)
 
     # POST fields in this table
     logger.info(
-        f"POST {len(field_entries_to_post)} fields to table "
-        f"{current_table_name}"
+        f"POST {len(field_entries_to_post)} fields to table {current_table_name}"
     )
     logger.debug(f"RAM memory % used: {psutil.virtual_memory()}")
 
-    fields_response_content = post_field_entries(
-        field_entries_to_post, scan_report_id
-    )
+    fields_response_content = post_field_entries(field_entries_to_post, scan_report_id)
 
     # Create a dictionary with field names and field ids from the response
     # as key value pairs
@@ -969,7 +973,7 @@ def process_all_fields_and_values(
     field_entries_to_post = []
 
     previous_row_value = None
-    for row in fo_ws.iter_rows(min_row=2, max_row=fo_ws.max_row+2):
+    for row in fo_ws.iter_rows(min_row=2, max_row=fo_ws.max_row + 2):
         # Guard against unnecessary rows beyond the last true row with contents
         if (previous_row_value is None or previous_row_value == "") and (
             row[0].value is None or row[0].value == ""
@@ -1004,11 +1008,25 @@ def process_all_fields_and_values(
             # This is the scenario where the line is empty, so we're at the end of
             # the table. Don't add a field entry, but process all those so far.
             # print("scan_report_field_entries >>>", field_entries_to_post)
-            post_table_entries(current_table_name, field_entries_to_post, scan_report_id, wb, data_dictionary, vocab_dictionary)
+            post_table_entries(
+                current_table_name,
+                field_entries_to_post,
+                scan_report_id,
+                wb,
+                data_dictionary,
+                vocab_dictionary,
+            )
             field_entries_to_post = []
     # Catch the final table if it wasn't already posted in the loop above - sometimes the iter_rows() seems to now allow you to go beyond the last row.
     if field_entries_to_post:
-        post_table_entries(current_table_name, field_entries_to_post, scan_report_id, wb, data_dictionary, vocab_dictionary)
+        post_table_entries(
+            current_table_name,
+            field_entries_to_post,
+            scan_report_id,
+            wb,
+            data_dictionary,
+            vocab_dictionary,
+        )
 
 
 # @memory_profiler.profile(stream=profiler_logstream)

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -396,9 +396,9 @@ def reuse_existing_field_concepts(new_fields_map, content_type, api_url, headers
             for mapping in existing_mappings_to_consider
             if mapping["name"] == name
         ]
-        target_concept_ids = set(
-            [mapping["concept"] for mapping in mappings_matching_field_name]
-        )
+        target_concept_ids = {
+            mapping["concept"] for mapping in mappings_matching_field_name
+        }
 
         if len(target_concept_ids) == 1:
             target_field_id = (

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -1059,7 +1059,7 @@ async def process_values_from_sheet(
     data_dictionary,
     vocab_dictionary,
     current_table_name,
-    names_to_ids_dict,
+    fieldnames_to_ids_dict,
     api_url,
     scan_report_id,
     headers,
@@ -1154,7 +1154,7 @@ async def process_values_from_sheet(
                 "frequency": int(frequency),
                 "conceptID": concept_id,
                 "value_description": val_desc,
-                "scan_report_field": names_to_ids_dict[name],
+                "scan_report_field": fieldnames_to_ids_dict[name],
             }
 
             # Append to list
@@ -1314,7 +1314,7 @@ async def process_values_from_sheet(
             )
 
     logger.info("PATCH values finished")
-    reuse_existing_field_concepts(names_to_ids_dict, 15, api_url, headers)
+    reuse_existing_field_concepts(fieldnames_to_ids_dict, 15, api_url, headers)
     reuse_existing_value_concepts(values_response_content, 17, api_url, headers)
     logger.debug(f"RAM memory % used: {psutil.virtual_memory()}")
 
@@ -1423,12 +1423,12 @@ def process_all_fields_and_values(
             # Create a dictionary with field names and field ids from the response
             # as key value pairs
             # e.g ("Field Name": Field ID)
-            names_to_ids_dict = {
+            fieldnames_to_ids_dict = {
                 str(element.get("name", None)): str(element.get("id", None))
                 for element in fields_response_content
             }
 
-            # print("Dictionary id:name", names_to_ids_dict)
+            # print("Dictionary id:name", fieldnames_to_ids_dict)
 
             if current_table_name not in wb.sheetnames:
                 process_failure(api_url, scan_report_id, headers)
@@ -1445,7 +1445,7 @@ def process_all_fields_and_values(
                     data_dictionary,
                     vocab_dictionary,
                     current_table_name,
-                    names_to_ids_dict,
+                    fieldnames_to_ids_dict,
                     api_url,
                     scan_report_id,
                     headers,

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -410,9 +410,6 @@ def reuse_existing_field_concepts(new_fields_map, content_type):
                 str(target_concept_ids.pop()),
             )
 
-    # replace existing_field_name_to_id_map with field name to concept id map
-    # field_name_to_concept_id_map = { element.key: existing_field_id_to_concept_map[int(element.value)] for element in field_name_to_id_map }
-
     logger.debug(f"{existing_field_name_to_field_and_concept_id_map=}")
     concepts_to_post = []
     logger.debug(f"{new_fields_map=}")

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -297,8 +297,7 @@ def flatten(arr):
     """
     This expects a list of lists and returns a flattened list
     """
-    newArr = [item for sublist in arr for item in sublist]
-    return newArr
+    return [item for sublist in arr for item in sublist]
 
 
 def post_paginated_concepts(concepts_to_post, api_url, headers):

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -326,6 +326,28 @@ def get_active_completed_scan_reports(api_url, headers):
     return active_srs
 
 
+def post_paginated_concepts(concepts_to_post, api_url, headers):
+    paginated_concepts_to_post = paginate(concepts_to_post)
+    concept_response = []
+    for concepts_to_post_item in paginated_concepts_to_post:
+        post_concept_response = requests.post(
+            url=api_url + "scanreportconcepts/",
+            headers=headers,
+            data=json.dumps(concepts_to_post_item),
+        )
+        logger.info(
+            f"CONCEPTS SAVE STATUS >>> "
+            f"{post_concept_response.status_code} "
+            f"{post_concept_response.reason}"
+        )
+        concept_response.append(
+            json.loads(post_concept_response.content.decode("utf-8"))
+        )
+    concept_content = flatten(concept_response)
+
+    concept_response_content += concept_content
+
+
 def reuse_existing_field_concepts(new_fields_map, content_type, api_url, headers):
     """
     This expects a dict of field names to ids which have been generated in a newly uploaded
@@ -510,26 +532,7 @@ def reuse_existing_field_concepts(new_fields_map, content_type, api_url, headers
             continue
 
     if concepts_to_post:
-        paginated_concepts_to_post = paginate(concepts_to_post)
-        concept_response = []
-        for concepts_to_post_item in paginated_concepts_to_post:
-            post_concept_response = requests.post(
-                url=api_url + "scanreportconcepts/",
-                headers=headers,
-                data=json.dumps(concepts_to_post_item),
-            )
-            logger.info(
-                f"CONCEPTS SAVE STATUS >>>"
-                f"{post_concept_response.status_code} "
-                f"{post_concept_response.reason}"
-            )
-            concept_response.append(
-                json.loads(post_concept_response.content.decode("utf-8"))
-            )
-        concept_content = flatten(concept_response)
-
-        concept_response_content += concept_content
-
+        post_paginated_concepts(concepts_to_post, api_url, headers)
         logger.info("POST concepts all finished in reuse_existing_field_concepts")
 
 
@@ -809,26 +812,7 @@ def reuse_existing_value_concepts(new_values_map, content_type, api_url, headers
             continue
 
     if concepts_to_post:
-        paginated_concepts_to_post = paginate(concepts_to_post)
-        concept_response = []
-        for concepts_to_post_item in paginated_concepts_to_post:
-            post_concept_response = requests.post(
-                url=api_url + "scanreportconcepts/",
-                headers=headers,
-                data=json.dumps(concepts_to_post_item),
-            )
-            logger.info(
-                f"CONCEPTS SAVE STATUS >>> "
-                f"{post_concept_response.status_code} "
-                f"{post_concept_response.reason}"
-            )
-            concept_response.append(
-                json.loads(post_concept_response.content.decode("utf-8"))
-            )
-        concept_content = flatten(concept_response)
-
-        concept_response_content += concept_content
-
+        post_paginated_concepts(concepts_to_post, api_url, headers)
         logger.info("POST concepts all finished in reuse_existing_value_concepts")
 
 

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -450,9 +450,7 @@ def reuse_existing_field_concepts(new_fields_map, content_type, api_url, headers
         f"{content_type}&fields=id,object_id,concept",
         headers=headers,
     )
-    existing_field_concepts = json.loads(
-        get_field_concepts.content.decode("utf-8")
-    )
+    existing_field_concepts = json.loads(get_field_concepts.content.decode("utf-8"))
     # create dictionary that maps existing field ids to scan report concepts
     # from the list of existing scan report concepts from active SRs
     existing_field_id_to_concept_map = {
@@ -479,8 +477,10 @@ def reuse_existing_field_concepts(new_fields_map, content_type, api_url, headers
         )
         existing_fields.append(json.loads(get_fields.content.decode("utf-8")))
     existing_fields = flatten(existing_fields)
-    logger.debug(f"ids and names of existing fields with concepts in active SRs:"
-                 f" {existing_fields}")
+    logger.debug(
+        f"ids and names of existing fields with concepts in active SRs:"
+        f" {existing_fields}"
+    )
 
     existing_mappings_to_consider = [
         {

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -497,6 +497,10 @@ def reuse_existing_field_concepts(new_fields_map, content_type, api_url, headers
         for name, new_field_id in new_fields_map.items()
     ]
 
+    # existing_field_name_to_field_and_concept_id_map will contain
+    # (field_name) -> (field_id, concept_id)
+    # for each field in new_fields_full_details
+    # if that field has only one match in existing_mappings_to_consider
     existing_field_name_to_field_and_concept_id_map = {}
     for item in new_fields_full_details:
         name = item["name"]
@@ -780,6 +784,10 @@ def reuse_existing_value_concepts(new_values_map, content_type, api_url, headers
     ]
     logger.debug(f"{existing_mappings_to_consider=}")
 
+    # value_details_to_value_and_concept_id_map will contain
+    # (name, description, field_name) -> (value_id, concept_id)
+    # for each value/description/field tuple in new_values_full_details
+    # if that tuple has only one match in existing_mappings_to_consider
     value_details_to_value_and_concept_id_map = {}
     for item in new_values_full_details:
         name = item["name"]

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -1,20 +1,21 @@
-import logging
-import json
-import azure.functions as func
-from azure.storage.blob import BlobServiceClient
-from io import BytesIO
-import requests
-import openpyxl
-from datetime import datetime
-import os
 import csv
-import psutil
-import httpx
-import asyncio
+import json
+import logging
+import os
 
-from requests.models import HTTPError
 from collections import defaultdict
+from datetime import datetime
+from io import BytesIO
 
+import asyncio
+import httpx
+import openpyxl
+import psutil
+import requests
+import azure.functions as func
+
+from azure.storage.blob import BlobServiceClient
+from requests.models import HTTPError
 from shared_code import omop_helpers
 
 # import memory_profiler

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -399,7 +399,7 @@ def reuse_existing_field_concepts(new_fields_map, content_type):
     scanreport, and content_type 15. It creates new concepts associated to any
     field that matches the name of an existing field with an associated concept.
     """
-    logger.info(f"reuse_existing_field_concepts")
+    logger.info("reuse_existing_field_concepts")
     # Gets all scan report concepts that are for the type field
     # (or content type which should be field) and in "active" SRs
     get_field_concepts = requests.get(
@@ -528,7 +528,7 @@ def reuse_existing_value_concepts(new_values_map, content_type):
         [str(element.get("object_id", None)) for element in existing_value_concepts],
         max_chars_for_get,
     )
-    logger.debug(f"paginated_existing_ids")
+    logger.debug("paginated_existing_ids")
 
     # for each list in paginated ids, get scanreport values that match any of the given
     # ids (those with an associated concept)
@@ -544,10 +544,10 @@ def reuse_existing_value_concepts(new_values_map, content_type):
         existing_values_filtered_by_id.append(
             json.loads(get_field_tables.content.decode("utf-8"))
         )
-    logger.debug(f"existing_values_filtered_by_id")
+    logger.debug("existing_values_filtered_by_id")
 
     existing_values_filtered_by_id = flatten(existing_values_filtered_by_id)
-    logger.debug(f"existing_values_filtered_by_id flattened")
+    logger.debug("existing_values_filtered_by_id flattened")
 
     # existing_values_filtered_by_id now contains the id,value,value_dec,
     # scan_report_field of each value got from the active concepts filter.

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -230,7 +230,7 @@ def startup(msg):
     headers = {
         "Content-type": "application/json",
         "charset": "utf-8",
-        "Authorization": "Token {}".format(os.environ.get("AZ_FUNCTION_KEY")),
+        "Authorization": f"Token {os.environ.get('AZ_FUNCTION_KEY')}",
     }
 
     # Get message from queue
@@ -507,9 +507,7 @@ def reuse_existing_value_concepts(new_values_map, content_type, api_url, headers
     # scan_report_field of each value got from the active concepts filter.
 
     # get field ids from values and use to get scan report fields' details
-    existing_field_ids = set(
-        [item["scan_report_field"] for item in existing_values_filtered_by_id]
-    )
+    existing_field_ids = {item["scan_report_field"] for item in existing_values_filtered_by_id}
     paginated_existing_field_ids = paginate(existing_field_ids, max_chars_for_get)
     existing_fields_details = []
     for ids in paginated_existing_field_ids:
@@ -608,9 +606,8 @@ def reuse_existing_value_concepts(new_values_map, content_type, api_url, headers
             and mapping["description"] == description
             and mapping["field_name"] == field_name
         ]
-        target_concept_ids = set(
-            [mapping["concept"] for mapping in mappings_matching_value_name]
-        )
+        target_concept_ids = {mapping["concept"] for mapping in
+                              mappings_matching_value_name}
 
         if len(target_concept_ids) == 1:
             target_value_id = (
@@ -849,7 +846,7 @@ def post_tables(fo_ws, api_url, scan_report_id, headers):
     logger.info("POST tables")
     # POST request to scanreporttables
     tables_response = requests.post(
-        "{}scanreporttables/".format(api_url),
+        url=f"{api_url}scanreporttables/",
         data=json.dumps(table_entries_to_post),
         headers=headers,
     )
@@ -1008,7 +1005,7 @@ async def process_values_from_sheet(
                 tasks.append(
                     asyncio.ensure_future(
                         client.post(
-                            url="{}scanreportvalues/".format(api_url),
+                            url=f"{api_url}scanreportvalues/",
                             data=json.dumps(page),
                             headers=headers,
                         )
@@ -1019,10 +1016,10 @@ async def process_values_from_sheet(
 
             values_responses = await asyncio.gather(*tasks)
 
-        for i, values_response in enumerate(values_responses):
+        for values_response, page_length in zip(values_responses, page_lengths):
             logger.info(
                 f"VALUES SAVE STATUSES >>> {values_response.status_code} "
-                f"{values_response.reason_phrase} {page_lengths[i]}"
+                f"{values_response.reason_phrase} {page_length}"
             )
 
             if values_response.status_code != 201:
@@ -1154,7 +1151,7 @@ def post_field_entries(field_entries_to_post, api_url, scan_report_id, headers):
     # POST Fields
     for page in paginated_field_entries_to_post:
         fields_response = requests.post(
-            "{}scanreportfields/".format(api_url),
+            url=f"{api_url}scanreportfields/",
             data=json.dumps(page),
             headers=headers,
         )

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -144,12 +144,12 @@ def process_scan_report_sheet_table(sheet):
     return d
 
 
-def default_zero(input):
+def default_zero(value):
     """
     Helper function that returns the input, replacing anything Falsey
     (such as Nones or empty strings) with 0.0.
     """
-    return round(input if input else 0.0, 2)
+    return round(value if value else 0.0, 2)
 
 
 def handle_max_chars(max_chars=None):

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -1197,7 +1197,7 @@ def process_all_fields_and_values(
     field_entries_to_post = []
 
     previous_row_value = None
-    for i, row in enumerate(fo_ws.iter_rows(min_row=2, max_row=fo_ws.max_row), start=2):
+    for row in fo_ws.iter_rows(min_row=2, max_row=fo_ws.max_row):
         # Guard against unnecessary rows beyond the last true row with contents
         if (previous_row_value is None or previous_row_value == "") and (
             row[0].value is None or row[0].value == ""

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -454,7 +454,6 @@ def reuse_existing_value_concepts(new_values_map, content_type):
         logger.info("POST concepts all finished in reuse_existing_value_concepts")
 
 
-
 # @memory_profiler.profile(stream=profiler_logstream)
 def process_scan_report_sheet_table(sheet):
     """

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -248,6 +248,8 @@ def select_concepts_to_post(
         except KeyError:
             continue
 
+    return concepts_to_post
+
 
 def reuse_existing_field_concepts(new_fields_map, content_type):
     """

--- a/ProcessQueue/blob_parser.py
+++ b/ProcessQueue/blob_parser.py
@@ -1,0 +1,158 @@
+import csv
+import os
+
+from io import BytesIO
+
+import openpyxl
+
+from azure.storage.blob import BlobServiceClient
+
+
+def remove_BOM(intermediate):
+    """
+    Given a list of dictionaries, remove any occurrences of the BOM in the keys
+    """
+    return [
+        {key.replace("\ufeff", ""): value for key, value in d.items()}
+        for d in intermediate
+    ]
+
+
+def process_three_item_dict(three_item_data):
+    """
+    Converts a list of dictionaries (each with keys 'csv_file_name', 'field_name' and
+    'code') to a nested dictionary with indices 'csv_file_name', 'field_name' and
+    internal value 'code'.
+
+    [{'csv_file_name': 'table1', 'field_name': 'field1', 'value': 'value1', 'code':
+    'code1'},
+    {'csv_file_name': 'table1', 'field_name': 'field2', 'value': 'value2'},
+    {'csv_file_name': 'table2', 'field_name': 'field2', 'value': 'value2', 'code':
+    'code2'},
+    {'csv_file_name': 'table3', 'field_name': 'field3', 'value': 'value3', 'code':
+    'code3'}]
+    ->
+    {'table1': {'field1': 'value1', 'field2': 'value2'},
+     'table2': {'field2': 'value2'},
+     'table3': {'field3': 'value3}
+    }
+    """
+    csv_file_names = set(row["csv_file_name"] for row in three_item_data)
+
+    # Initialise the dictionary with the keys, and each value set to a blank dict()
+    new_vocab_dictionary = dict.fromkeys(csv_file_names, {})
+
+    # Fill each subdict with the data from the input list
+    for row in three_item_data:
+        new_vocab_dictionary[row["csv_file_name"]][row["field_name"]] = row["code"]
+
+    return new_vocab_dictionary
+
+
+def process_four_item_dict(four_item_data):
+    """
+    Converts a list of dictionaries (each with keys 'csv_file_name', 'field_name' and
+    'code' and 'value') to a nested dictionary with indices 'csv_file_name',
+    'field_name', 'code', and internal value 'value'.
+
+    [{'csv_file_name': 'table1', 'field_name': 'field1', 'value': 'value1', 'code':
+    'code1'},
+    {'csv_file_name': 'table1', 'field_name': 'field2', 'value': 'value2', 'code':
+    'code2'},
+    {'csv_file_name': 'table2', 'field_name': 'field2', 'value': 'value2', 'code':
+    'code2'},
+    {'csv_file_name': 'table2', 'field_name': 'field2', 'value': 'value3', 'code':
+    'code3'},
+    {'csv_file_name': 'table3', 'field_name': 'field3', 'value': 'value3', 'code':
+    'code3'}]
+    ->
+    {'table1': {'field1': {'value1': 'code1'}, 'field2': {'value2': 'code2'}},
+     'table2': {'field2': {'value2': 'code2', 'value3': 'code3'}},
+     'table3': {'field3': {'value3': 'code3'}}
+    }
+    """
+    csv_file_names = set(row["csv_file_name"] for row in four_item_data)
+
+    # Initialise the dictionary with the keys, and each value set to a blank dict()
+    new_data_dictionary = dict.fromkeys(csv_file_names, {})
+
+    for row in four_item_data:
+        if row["field_name"] not in new_data_dictionary[row["csv_file_name"]]:
+            new_data_dictionary[row["csv_file_name"]][row["field_name"]] = {}
+        new_data_dictionary[row["csv_file_name"]][row["field_name"]][row["code"]] = row[
+            "value"
+        ]
+
+    return new_data_dictionary
+
+
+# @memory_profiler.profile(stream=profiler_logstream)
+def parse_blobs(scan_report_blob, data_dictionary_blob):
+    """
+    Given two strings, download the two files so named in the storage account given
+    by the STORAGE_CONN_STRING environment variable.
+
+    Open the scan_reort_blob in memory.
+
+    Split the contents of data_dictionary_blob into two parts, each of which is a
+    nested dictionary.
+
+    Return all 3.
+    """
+    # Set Storage Account connection string
+    blob_service_client = BlobServiceClient.from_connection_string(
+        os.environ.get("STORAGE_CONN_STRING")
+    )
+
+    # Grab scan report data from blob
+    streamdownloader = (
+        blob_service_client.get_container_client("scan-reports")
+        .get_blob_client(scan_report_blob)
+        .download_blob()
+    )
+    scanreport_bytes = BytesIO(streamdownloader.readall())
+    workbook = openpyxl.load_workbook(
+        scanreport_bytes, data_only=True, keep_links=False, read_only=True
+    )
+
+    # If dictionary is present, also download dictionary
+    if data_dictionary_blob != "None":
+        # Access data as StorageStreamerDownloader class
+        # Decode and split the stream using csv.reader()
+        dict_client = blob_service_client.get_container_client("data-dictionaries")
+        blob_dict_client = dict_client.get_blob_client(data_dictionary_blob)
+
+        # Grab all rows with 4 elements for use as value descriptions
+        data_dictionary_intermediate = list(
+            row
+            for row in csv.DictReader(
+                blob_dict_client.download_blob().readall().decode("utf-8").splitlines()
+            )
+            if row["value"] != ""
+        )
+        # Remove BOM from start of file if it's supplied.
+        dictionary_data = remove_BOM(data_dictionary_intermediate)
+
+        # Convert to nested dictionaries, with structure
+        # {tables: {fields: {values: value description}}}
+        data_dictionary = process_four_item_dict(dictionary_data)
+
+        # Grab all rows with 3 elements for use as possible vocabs
+        vocab_dictionary_intermediate = list(
+            row
+            for row in csv.DictReader(
+                blob_dict_client.download_blob().readall().decode("utf-8").splitlines()
+            )
+            if row["value"] == ""
+        )
+        vocab_data = remove_BOM(vocab_dictionary_intermediate)
+
+        # Convert to nested dictionaries, with structure
+        # {tables: {fields: vocab}}
+        vocab_dictionary = process_three_item_dict(vocab_data)
+
+    else:
+        data_dictionary = None
+        vocab_dictionary = None
+
+    return workbook, data_dictionary, vocab_dictionary

--- a/ProcessQueue/helpers.py
+++ b/ProcessQueue/helpers.py
@@ -1,0 +1,121 @@
+import json
+import os
+import requests
+
+# Set up ccom API parameters:
+API_URL = os.environ.get("APP_URL") + "api/"
+HEADERS = {
+    "Content-type": "application/json",
+    "charset": "utf-8",
+    "Authorization": f"Token {os.environ.get('AZ_FUNCTION_KEY')}",
+}
+
+
+def process_failure(scan_report_id):
+    scan_report_fetched_data = requests.get(
+        url=f"{API_URL}scanreports/{scan_report_id}/",
+        headers=HEADERS,
+    )
+
+    scan_report_fetched_data = scan_report_fetched_data.json()
+
+    json_data = json.dumps({"status": "UPFAILE"})
+
+    failure_response = requests.patch(
+        url=f"{API_URL}scanreports/{scan_report_id}/", data=json_data, headers=HEADERS
+    )
+
+
+def flatten(arr):
+    """
+    This expects a list of lists and returns a flattened list
+    """
+    return [item for sublist in arr for item in sublist]
+
+
+def default_zero(value):
+    """
+    Helper function that returns the input, replacing anything Falsey
+    (such as Nones or empty strings) with 0.0.
+    """
+    return round(value if value else 0.0, 2)
+
+
+def handle_max_chars(max_chars=None):
+    if not max_chars:
+        max_chars = (
+            int(os.environ.get("PAGE_MAX_CHARS"))
+            if os.environ.get("PAGE_MAX_CHARS")
+            else 10000
+        )
+    return max_chars
+
+
+def perform_chunking(entries_to_post):
+    """
+    This expects a list of dicts, and returns a list of lists of lists of dicts,
+    where the maximum length of each list of dicts, under JSONification,
+    is less than max_chars, and the length of each list of lists of dicts is chunk_size
+    """
+    max_chars = handle_max_chars()
+    chunk_size = (
+        int(os.environ.get("CHUNK_SIZE")) if os.environ.get("CHUNK_SIZE") else 6
+    )
+
+    chunked_entries_to_post = []
+    this_page = []
+    this_chunk = []
+    page_no = 0
+    for entry in entries_to_post:
+        # If the current page won't be overfull, add the entry to the current page
+        if len(json.dumps(this_page)) + len(json.dumps(entry)) < max_chars:
+            this_page.append(entry)
+        # Otherwise, this page should be added to the current chunk.
+        else:
+            this_chunk.append(this_page)
+            page_no += 1
+            # Now check for a full chunk. If full, then add this chunk to the list
+            # of chunks.
+            if page_no % chunk_size == 0:
+                # append the chunk to the list of chunks, then reset the chunk to empty
+                chunked_entries_to_post.append(this_chunk)
+                this_chunk = []
+            # Now add the entry that would have over-filled the page.
+            this_page = [entry]
+    # After all entries are added, check for a half-filled page, and if present add
+    # it to the list of pages
+    if this_page:
+        this_chunk.append(this_page)
+    # Similarly, if a chunk ends up half-filled, add it to thelist of chunks
+    if this_chunk:
+        chunked_entries_to_post.append(this_chunk)
+
+    return chunked_entries_to_post
+
+
+def paginate(entries, max_chars=None):
+    """
+    This expects a list of strings, and returns a list of lists of strings,
+    where the maximum length of each list of strings, under JSONification,
+    is less than max_chars
+    """
+    max_chars = handle_max_chars(max_chars)
+
+    paginated_entries = []
+    this_page = []
+    for entry in entries:
+        # If the current page won't be overfull, add the entry to the current page
+        if len(json.dumps(this_page)) + len(json.dumps(entry)) < max_chars:
+            this_page.append(entry)
+        else:
+            # Otherwise, this page should be added to the list of pages.
+            paginated_entries.append(this_page)
+            # Now add the entry that would have over-filled the page.
+            this_page = [entry]
+
+    # After all entries are added, check for a half-filled page, and if present add
+    # it to the list of pages
+    if this_page:
+        paginated_entries.append(this_page)
+
+    return paginated_entries

--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -74,6 +74,13 @@ routers.register(
 )
 
 routers.register(
+    r"scanreportactiveconceptfilter",
+    views.ScanReportActiveConceptFilterViewSet,
+    basename="scanreportactiveconceptfilter",
+)
+
+
+routers.register(
     r"scanreportvaluesfilterscanreport",
     views.ScanReportValuesFilterViewSetScanReport,
     basename="scanreportvaluesfilterscanreport",

--- a/api/mapping/urls.py
+++ b/api/mapping/urls.py
@@ -67,6 +67,11 @@ routers.register(
 #     views.ScanReportValueFilterViewSet,
 #     basename="scanreportvaluesfilter",
 # )
+routers.register(
+    r"scanreportfilter",
+    views.ScanReportFilterViewSet,
+    basename="scanreportfilter",
+)
 
 routers.register(
     r"scanreportvaluesfilterscanreport",

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -831,6 +831,18 @@ class ScanReportValueViewSet(viewsets.ModelViewSet):
 #     }
 
 
+class ScanReportFilterViewSet(viewsets.ModelViewSet):
+    queryset = ScanReport.objects.all()
+    serializer_class = ScanReportViewSerializer
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = {
+        "id": ["in", "exact"],
+        "status": ["in", "exact"],
+        "hidden": ["in", "exact"],
+        "parent_dataset__hidden": ["in", "exact"],
+    }
+
+
 class ScanReportValuesFilterViewSetScanReport(viewsets.ModelViewSet):
     serializer_class = ScanReportValueViewSerializer
     filter_backends = [DjangoFilterBackend]

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -694,6 +694,7 @@ class ScanReportActiveConceptFilterViewSet(viewsets.ModelViewSet):
     in ScanReports that are "active" - that is, not hidden, with unhidden parent
     dataset, and marked with status "Mapping Complete"
     """
+
     serializer_class = ScanReportConceptSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["content_type"]

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -692,7 +692,8 @@ class ScanReportActiveConceptFilterViewSet(viewsets.ModelViewSet):
     """
     This returns details of ScanReportConcepts that have the given content_type and are
     in ScanReports that are "active" - that is, not hidden, with unhidden parent
-    dataset, and marked with status "Mapping Complete"
+    dataset, and marked with status "Mapping Complete".
+    This is only retrievable by AZ_FUNCTION_USER.
     """
 
     serializer_class = ScanReportConceptSerializer
@@ -700,32 +701,35 @@ class ScanReportActiveConceptFilterViewSet(viewsets.ModelViewSet):
     filterset_fields = ["content_type"]
 
     def get_queryset(self):
-        if self.request.GET["content_type"] == "15":
-            # ScanReportField
-            # we have SRCs with content_type 15, grab all SRFields in active SRs,
-            # and then filter ScanReportConcepts by those object_ids
-            field_ids = ScanReportField.objects.filter(
-                scan_report_table__scan_report__hidden=False,
-                scan_report_table__scan_report__parent_dataset__hidden=False,
-                scan_report_table__scan_report__status="COMPLET",
-            )
-            qs = ScanReportConcept.objects.filter(
-                content_type=15, object_id__in=field_ids
-            )
-            return qs
-        elif self.request.GET["content_type"] == "17":  #
-            # ScanReportValue
-            # we have SRCs with content_type 17, grab all SRValues in active SRs,
-            # and then filter ScanReportConcepts by those object_ids
-            value_ids = ScanReportValue.objects.filter(
-                scan_report_field__scan_report_table__scan_report__hidden=False,
-                scan_report_field__scan_report_table__scan_report__parent_dataset__hidden=False,
-                scan_report_field__scan_report_table__scan_report__status="COMPLET",
-            )
-            qs = ScanReportConcept.objects.filter(
-                content_type=17, object_id__in=value_ids
-            )
-            return qs
+        if self.request.user.username == os.getenv("AZ_FUNCTION_USER"):
+
+            if self.request.GET["content_type"] == "15":
+                # ScanReportField
+                # we have SRCs with content_type 15, grab all SRFields in active SRs,
+                # and then filter ScanReportConcepts by those object_ids
+                field_ids = ScanReportField.objects.filter(
+                    scan_report_table__scan_report__hidden=False,
+                    scan_report_table__scan_report__parent_dataset__hidden=False,
+                    scan_report_table__scan_report__status="COMPLET",
+                )
+                qs = ScanReportConcept.objects.filter(
+                    content_type=15, object_id__in=field_ids
+                )
+                return qs
+            elif self.request.GET["content_type"] == "17":  #
+                # ScanReportValue
+                # we have SRCs with content_type 17, grab all SRValues in active SRs,
+                # and then filter ScanReportConcepts by those object_ids
+                value_ids = ScanReportValue.objects.filter(
+                    scan_report_field__scan_report_table__scan_report__hidden=False,
+                    scan_report_field__scan_report_table__scan_report__parent_dataset__hidden=False,
+                    scan_report_field__scan_report_table__scan_report__status="COMPLET",
+                )
+                qs = ScanReportConcept.objects.filter(
+                    content_type=17, object_id__in=value_ids
+                )
+                return qs
+            return None
         return None
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,12 +10,16 @@ Please append a line to the changelog for each change made.
 * `viewers` and `editors` set on SR when uploaded.
 * `editors` set on creation of new dataset on SR upload page.
 * `editors` and `admins` field for dataset shown for PUBLIC dataset as well as RESTRICTED.
+* Mapping rule reuse is much faster and the code is cleaner.
+* Scan Report upload code has been reorganised for clarity.
 
 ### Bugfixes
 * Fixed error 500 when trying to build mapping rules diagram without rules.
 * Admins specified by the user for Datasets on the SR upload form will now be added along with the user - who is already made an admin by default.
   * Added tooltip to the form to explain this.
 * All URLs now end in a slash (`/`).
+* Fixed a bug where the contents of the final table was not uploaded in some circumstances.
+* Fixed a bug where empty cells in individual field sheets were creating None records.
 
 ## v2.0.0 was released 04/05/22
 


### PR DESCRIPTION
# Changes

This PR rewrites much of the ProcessQueue Azure Function, and introduces new endpoints to simplify the code. In particular, it
- rewrites the value/field reuse functions using new API endpoints which move significant portions of frontend code to the backend and in a much more concise form.
- splits out a number of the helper functions into two new files: `helpers.py` and `blob_parser.py`.
- reorders the definitions of a number of functions to clarify their relationships.
- fixes a bug where the contents of the final table was not uploaded in some circumstances.
- fixes a bug where empty cells in individual field sheets were creating None records.

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
