### PR TITLE
Fix bug where last vocab was being set for fields with the same name.

### DIFF
--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -603,7 +603,7 @@ async def process_values_from_sheet(
                             no_source_concept=True,
                         )
                         concept_id = concept_id["concept_id"]
-                    except:
+                    except RuntimeWarning:
                         concept_id = -1
                 else:
                     concept_id = -1

--- a/ProcessQueue/blob_parser.py
+++ b/ProcessQueue/blob_parser.py
@@ -6,6 +6,8 @@ from io import BytesIO
 import openpyxl
 
 from azure.storage.blob import BlobServiceClient
+import logging
+logger = logging.getLogger("test_logger")
 
 
 def remove_BOM(intermediate):
@@ -40,7 +42,7 @@ def process_three_item_dict(three_item_data):
     csv_file_names = set(row["csv_file_name"] for row in three_item_data)
 
     # Initialise the dictionary with the keys, and each value set to a blank dict()
-    new_vocab_dictionary = dict.fromkeys(csv_file_names, {})
+    new_vocab_dictionary = dict((filename, {}) for filename in csv_file_names)
 
     # Fill each subdict with the data from the input list
     for row in three_item_data:

--- a/ProcessQueue/blob_parser.py
+++ b/ProcessQueue/blob_parser.py
@@ -42,7 +42,7 @@ def process_three_item_dict(three_item_data):
     csv_file_names = set(row["csv_file_name"] for row in three_item_data)
 
     # Initialise the dictionary with the keys, and each value set to a blank dict()
-    new_vocab_dictionary = dict((filename, {}) for filename in csv_file_names)
+    new_vocab_dictionary = {filename: {} for filename in csv_file_names}
 
     # Fill each subdict with the data from the input list
     for row in three_item_data:

--- a/ProcessQueue/blob_parser.py
+++ b/ProcessQueue/blob_parser.py
@@ -7,6 +7,7 @@ import openpyxl
 
 from azure.storage.blob import BlobServiceClient
 import logging
+
 logger = logging.getLogger("test_logger")
 
 

--- a/shared_code/omop_helpers.py
+++ b/shared_code/omop_helpers.py
@@ -1,5 +1,6 @@
 import requests, os, time
 import logging
+
 api_url = os.environ.get("APP_URL") + "api/"
 api_header = {"Authorization": "Token {}".format(os.environ.get("AZ_FUNCTION_KEY"))}
 logger = logging.getLogger("test_logger")
@@ -56,7 +57,7 @@ def get_concept_from_concept_code(concept_code, vocabulary_id, no_source_concept
 
     source_concept = source_concept.json()
     if len(source_concept) == 0:
-        raise RuntimeWarning('concept_code not recognised in vocab')
+        raise RuntimeWarning("concept_code not recognised in vocab")
     source_concept = source_concept[0]
     # if the source_concept is standard
     if source_concept["standard_concept"] == "S":

--- a/shared_code/omop_helpers.py
+++ b/shared_code/omop_helpers.py
@@ -1,7 +1,8 @@
-import requests, json, os, time
-
+import requests, os, time
+import logging
 api_url = os.environ.get("APP_URL") + "api/"
 api_header = {"Authorization": "Token {}".format(os.environ.get("AZ_FUNCTION_KEY"))}
+logger = logging.getLogger("test_logger")
 
 
 def find_standard_concept(source_concept):
@@ -15,7 +16,7 @@ def find_standard_concept(source_concept):
         },
     )
 
-    concept_relation = json.loads(concept_relation.content.decode("utf-8"))
+    concept_relation = concept_relation.json()
     concept_relation = concept_relation[0]
 
     if concept_relation["concept_id_2"] != concept_relation["concept_id_1"]:
@@ -24,7 +25,7 @@ def find_standard_concept(source_concept):
             headers=api_header,
             params={"concept_id": concept_relation["concept_id_2"]},
         )
-        concept = json.loads(concept.content.decode("utf-8"))
+        concept = concept.json()
         concept = concept[0]
         return concept
     else:
@@ -53,9 +54,10 @@ def get_concept_from_concept_code(concept_code, vocabulary_id, no_source_concept
         params={"concept_code": concept_code, "vocabulary_id": vocabulary_id},
     )
 
-    source_concept = json.loads(source_concept.content.decode("utf-8"))
+    source_concept = source_concept.json()
+    if len(source_concept) == 0:
+        raise RuntimeWarning('concept_code not recognised in vocab')
     source_concept = source_concept[0]
-
     # if the source_concept is standard
     if source_concept["standard_concept"] == "S":
         # the concept is the same as the source_concept


### PR DESCRIPTION
# Changes

- Fixed bug where a dict of dicts was incorrectly being created with a single dict as the interior object. This resulted in any fields with the same name ending up with the last vocab assigned to that name. So if 2 tables have the field "a" with different vocabs assigned to each, they'd both end up assigned to just the last such vocab as defined in the data dictionary. This is fixed by ensuring the interior dictionaries are separate instances, rather than a single instance.
- Also added logger to blob_parser.py and omop_helpers.py, 
- Shortened a couple of json calls.

# Migrations

NA

# Screenshots

NA

# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
