### PR TITLE
Add procedure_occurrence and specimen as allowed tables in services_rules.py

### DIFF
--- a/api/mapping/services_rules.py
+++ b/api/mapping/services_rules.py
@@ -26,6 +26,8 @@ m_allowed_tables = [
     "condition_occurrence",
     "observation",
     "drug_exposure",
+    "procedure_occurrence",
+    "specimen",
 ]
 
 # look up of date-events in all the allowed (destination) tables
@@ -35,6 +37,8 @@ m_date_field_mapper = {
     "measurement": ["measurement_datetime"],
     "observation": ["observation_datetime"],
     "drug_exposure": ["drug_exposure_start_datetime", "drug_exposure_end_datetime"],
+    "procedure_occurrence": ["procedure_datetime"],
+    "specimen": ["specimen_datetime"],
 }
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,13 +2,14 @@
 
 Please append a line to the changelog for each change made.
 
-##v2.1.0-beta
+##v2.0.2
 ### New features
 
 ### Improvements
 
 ### Bugfixes
 * Improved error message when attempting to upload to a Dataset without editor or admin permissions.
+* Fixed an issue where procedure_occurrence and specimen rules were not correctly created when refreshing rules.
 
 ## v2.0.1 was released 27/05/22
 ### New Features

--- a/react-client-app/src/api/values.js
+++ b/react-client-app/src/api/values.js
@@ -192,11 +192,11 @@ const saveMappingRules = async (scan_report_concept,scan_report_value,table) => 
     const m_date_field_mapper = {
         'person': ['birth_datetime'],
         'condition_occurrence': ['condition_start_datetime','condition_end_datetime'],
-        'measurement':['measurement_datetime'],
-        'observation':['observation_datetime'],
-        'drug_exposure':['drug_exposure_start_datetime','drug_exposure_end_datetime'],
-	'procedure_occurrence':['procedure_datetime'],
-	'specimen':['specimen_datetime']
+        'measurement': ['measurement_datetime'],
+        'observation': ['observation_datetime'],
+        'drug_exposure': ['drug_exposure_start_datetime','drug_exposure_end_datetime'],
+        'procedure_occurrence': ['procedure_datetime'],
+        'specimen': ['specimen_datetime']
         }
     const destination_field = await cachedOmopFunction(fields,domain+"_source_concept_id")
     // if a destination field can't be found for concept domain, return error
@@ -210,8 +210,8 @@ const saveMappingRules = async (scan_report_concept,scan_report_value,table) => 
     {
         scan_report:table.scan_report,
         concept: scan_report_concept.id, 
-        approved:true,
-        creation_type:"M",
+        approved: true,
+        creation_type: "M",
     }
     // create mapping rule for the following
     //person_id
@@ -251,8 +251,8 @@ const saveMappingRules = async (scan_report_concept,scan_report_value,table) => 
         promises.push(usePost(`/mappingrules/`,data))
     }  
     // when all requests have finished, return
-        const values = await Promise.all(promises)
-        return values
+    const values = await Promise.all(promises)
+    return values
 }
 //function to map concept domain to an omop field
 const mapConceptToOmopField = () =>{


### PR DESCRIPTION
# Changes

Add procedure_occurrence and specimen as allowed tables in services_rules.py. These had been missed when these tables had been added in `react-client-app/src/api/values.js`. This was manifesting in the following behaviour:
- Add a Concept from procedure_occurrence, e.g. "4015846 Quarantine" manually.
- Check the rules page, and this rule will be present.
- Click "Refresh rules", and notice that this rule disappears. This is because "Refresh Rules" removes the existing rules and rebuilds them from the Concepts registered. But with `procedure_occurrence` absent from the `m_allowed_tables` list, this rule failed and was not built.

Fix is to add `procedure_occurrence` and `specimen` to `m_allowed_tables`.

This PR also does a tiny bit of reformatting of white space.

# Migrations

NA

# Screenshots

NA

# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
