### PR TITLE
Raise errors earlier in the run_fast_consistency_checks() code

### DIFF
--- a/api/mapping/forms.py
+++ b/api/mapping/forms.py
@@ -180,6 +180,7 @@ class ScanReportForm(forms.Form):
                     f"You provided \n{source_headers[:10]}"
                 )
             )
+            raise ValidationError(errors)
 
         # Check tables are correctly separated in FO - a single empty line between each
         # table
@@ -201,6 +202,9 @@ class ScanReportForm(forms.Form):
                     )
                 )
             cell_above = cell
+
+        if errors:
+            raise ValidationError(errors)
 
         # Now that we're happy that the FO sheet is correctly formatted, we can move
         # on to comparing its contents to the sheets
@@ -239,6 +243,9 @@ class ScanReportForm(forms.Form):
                         f"not have matching sheets supplied."
                     )
                 )
+
+        if errors:
+            raise ValidationError(errors)
 
         # Loop over the rows, and for each table, once we reach the end of the table,
         # compare the fields provided with the fields in the associated sheet

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,16 @@
 
 Please append a line to the changelog for each change made.
 
-##v2.0.2
+## v2.0.3-beta
+### New features
+
+### Improvements
+* Improved error message reporting while checking the structure of uploaded files for consistency.
+
+### Bugfixes
+
+
+## v2.0.2
 ### New features
 
 ### Improvements


### PR DESCRIPTION
Raise errors earlier in the run_fast_consistency_checks() code to avoid unhelpful 500 error caused by running into a KeyError which had already been logged in errors but not yet raised.

# Changes

Errors are raised earlier. This means not all errors get caught in a single pass, meaning users may have to fix one error, resubmit, and find more errors, but this is preferable to the current situation.

# Migrations

None

# Screenshots

None

# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
