### PR TITLE
Get available vocabs in ProcessQueue by querying the DB

### DIFF
--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -31,35 +31,6 @@ stream_handler.setFormatter(
 logger.addHandler(stream_handler)
 logger.setLevel(logging.INFO)  # Set to logging.DEBUG to show the debug output
 
-
-# Agreed vocabs that are accepted for lookup/conversion
-# The Data Team decide what vocabs are accepted.
-# Add more as necessary by appending the list
-vocabs = [
-    "ABMS",
-    "ATC",
-    "HCPCS",
-    "HES Specialty",
-    "ICD10",
-    "ICD10CM",
-    "ICD10PCS",
-    "ICD9CM",
-    "ICD9Proc",
-    "LOINC",
-    "NDC",
-    "NUCC",
-    "OMOP Extension",
-    "OSM",
-    "PHDSC",
-    "Read",
-    "RxNorm",
-    "RxNorm Extension",
-    "SNOMED",
-    "SPL",
-    "UCUM",
-    "UK Biobank",
-]
-
 max_chars_for_get = 2000
 
 # Set up ccom API parameters:
@@ -69,6 +40,13 @@ HEADERS = {
     "charset": "utf-8",
     "Authorization": f"Token {os.environ.get('AZ_FUNCTION_KEY')}",
 }
+
+# Look up vocabs from the omop.vocabulary table.
+vocabs_raw = requests.get(
+        url=f"{API_URL}omop/vocabularies/",
+        headers=HEADERS,
+    )
+vocabs = [vocab['vocabulary_id'] for vocab in vocabs_raw.json()]
 
 
 def post_paginated_concepts(concepts_to_post):

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -43,10 +43,10 @@ HEADERS = {
 
 # Look up vocabs from the omop.vocabulary table.
 vocabs_raw = requests.get(
-        url=f"{API_URL}omop/vocabularies/",
-        headers=HEADERS,
-    )
-vocabs = [vocab['vocabulary_id'] for vocab in vocabs_raw.json()]
+    url=f"{API_URL}omop/vocabularies/",
+    headers=HEADERS,
+)
+vocabs = [vocab["vocabulary_id"] for vocab in vocabs_raw.json()]
 
 
 def post_paginated_concepts(concepts_to_post):


### PR DESCRIPTION
# Changes
Get available vocabs in ProcessQueue by querying the DB rather than hardcoded values. This means we can add further values just by updating the DB rather than having to redeploy code.

# Migrations

None

# Screenshots

None

# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
