### PR TITLE
Vocab parallelisation

### DIFF
--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -165,7 +165,9 @@ class ConceptRelationshipFilterViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = ConceptRelationship.objects.all()
     serializer_class = ConceptRelationshipSerializer
     filter_backends = [DjangoFilterBackend]
-    filterset_fields = ["concept_id_1", "concept_id_2", "relationship_id"]
+    filterset_fields = {"concept_id_1": ["in", "exact"],
+                        "concept_id_2": ["in", "exact"],
+                        "relationship_id": ["in", "exact"]}
 
 
 class ConceptAncestorViewSet(viewsets.ReadOnlyModelViewSet):

--- a/shared_code/omop_helpers.py
+++ b/shared_code/omop_helpers.py
@@ -69,7 +69,7 @@ def find_standard_concept(source_concept):
     # Concepts table, then return no concept, and the mapping will not go ahead.
     logger.info(f"concept filter of {relation['concept_id_2']} (from "
                 f"{relation['concept_id_1']} returned empty")
-    source_concept["concept_id"] =  -1
+    source_concept["concept_id"] = -1
     return source_concept
 
 

--- a/shared_code/omop_helpers.py
+++ b/shared_code/omop_helpers.py
@@ -1,5 +1,6 @@
 import requests, os, time
 import logging
+import asyncio
 
 api_url = os.environ.get("APP_URL") + "api/"
 api_header = {"Authorization": "Token {}".format(os.environ.get("AZ_FUNCTION_KEY"))}
@@ -38,7 +39,8 @@ def find_standard_concept(source_concept):
         return source_concept
 
 
-def get_concept_from_concept_code(concept_code, vocabulary_id, no_source_concept=False):
+async def get_concept_from_concept_code(concept_code, vocabulary_id, client,
+                                        no_source_concept=False):
 
     # NLP returns SNOMED as SNOWMEDCT_US
     # This sets SNOWMEDCT_US to SNOWMED if this function is
@@ -51,11 +53,17 @@ def get_concept_from_concept_code(concept_code, vocabulary_id, no_source_concept
         vocabulary_id = "RxNorm"
 
     # obtain the source_concept given the code and vocab
-    source_concept = requests.get(
-        url=api_url + "omop/conceptsfilter",
+    source_concept = await client.get(
+        url=api_url + "omop/conceptsfilter/",
         headers=api_header,
         params={"concept_code": concept_code, "vocabulary_id": vocabulary_id},
     )
+
+    # source_concept = requests.get(
+    #     url=api_url + "omop/conceptsfilter",
+    #     headers=api_header,
+    #     params={"concept_code": concept_code, "vocabulary_id": vocabulary_id},
+    # )
 
     source_concept = source_concept.json()
     if len(source_concept) == 0:


### PR DESCRIPTION
# Changes

This PR reworks the handling of automatic ScanReportConcept creation from vocabularies. Previously this was serial, and this PR rewrites much of it for either parallelisation or for making use of batch requests where possible. 

# Migrations

None

# Screenshots

None

# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
