### PR TITLE
SRValue upload rewrite

### DIFF
--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -31,8 +31,6 @@ stream_handler.setFormatter(
 logger.addHandler(stream_handler)
 logger.setLevel(logging.INFO)  # Set to logging.DEBUG to show the debug output
 
-max_chars_for_get = 2000
-
 # Set up ccom API parameters:
 API_URL = os.environ.get("APP_URL") + "api/"
 HEADERS = {
@@ -122,7 +120,7 @@ async def post_chunks(chunked_data, endpoint, text_string, table_name, scan_repo
 
 def get_existing_fields_from_ids(existing_field_ids):
     paginated_existing_field_ids = helpers.paginate(
-        existing_field_ids, max_chars_for_get
+        existing_field_ids, omop_helpers.max_chars_for_get
     )
 
     # for each list in paginated ids, get scanreport fields that match any of the given
@@ -340,7 +338,7 @@ def reuse_existing_value_concepts(new_values_map, content_type):
     # get details of existing selected values, for the purpose of matching against
     # new values
     existing_paginated_value_ids = helpers.paginate(
-        [value["object_id"] for value in existing_value_concepts], max_chars_for_get
+        [value["object_id"] for value in existing_value_concepts], omop_helpers.max_chars_for_get
     )
     logger.debug(f"{existing_paginated_value_ids=}")
 
@@ -397,7 +395,7 @@ def reuse_existing_value_concepts(new_values_map, content_type):
 
     # Now handle the newly-added values in a similar manner
     new_paginated_field_ids = helpers.paginate(
-        [value["scan_report_field"] for value in new_values_map], max_chars_for_get
+        [value["scan_report_field"] for value in new_values_map], omop_helpers.max_chars_for_get
     )
     logger.debug("new_paginated_field_ids")
 
@@ -709,7 +707,7 @@ async def process_values_from_sheet(
             logger.info(f"begin {vocab}")
             paginated_values_in_this_vocab = helpers.paginate(
                 (str(entry["value"]) for entry in entries_split_by_vocab[vocab]),
-                max_chars=max_chars_for_get,
+                max_chars=omop_helpers.max_chars_for_get,
             )
 
             concept_vocab_response = []

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -555,7 +555,8 @@ async def process_values_from_sheet(
         for entry in a:
             if data_dictionary.get(str(entry["table"])):  # dict of fields in table
                 if data_dictionary[str(entry["table"])].get(
-                        str(entry["fieldname"])):  # dict of values in field in table
+                    str(entry["fieldname"])
+                ):  # dict of values in field in table
                     entry["val_desc"] = data_dictionary[str(entry["table"])][
                         str(entry["fieldname"])
                     ].get(str(entry["full_value"]))
@@ -568,16 +569,18 @@ async def process_values_from_sheet(
     # --------------------------------------------------------------------------------
     # Convert basic information about SRValues into entries for posting to the endpoint.
     logger.debug("create value_entries_to_post")
-    value_entries_to_post = [{
-        "created_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-        "updated_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-        "value": entry["full_value"],
-        "frequency": int(entry["frequency"]),
-        # "conceptID": -1,
-        "value_description": entry["val_desc"],
-        "scan_report_field": fieldnames_to_ids_dict[entry["fieldname"]],
-    }
-        for entry in a]
+    value_entries_to_post = [
+        {
+            "created_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            "updated_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            "value": entry["full_value"],
+            "frequency": int(entry["frequency"]),
+            # "conceptID": -1,
+            "value_description": entry["val_desc"],
+            "scan_report_field": fieldnames_to_ids_dict[entry["fieldname"]],
+        }
+        for entry in a
+    ]
 
     # print(value_entries_to_post)
 
@@ -645,7 +648,7 @@ async def process_values_from_sheet(
     logger.debug("GET posted values")
     get_details_of_posted_values = requests.get(
         url=f"{API_URL}scanreportvaluesfilterscanreporttable/?scan_report_table"
-            f"={current_table_id}",
+        f"={current_table_id}",
         headers=HEADERS,
     )
     logger.debug("GET posted values finished")
@@ -663,8 +666,11 @@ async def process_values_from_sheet(
         for previously_posted_value in details_of_posted_values:
             if vocab_dictionary.get(str(current_table_name)):
                 vocab_id = vocab_dictionary[str(current_table_name)].get(
-                    str(fieldids_to_names_dict[
-                            str(previously_posted_value["scan_report_field"])])
+                    str(
+                        fieldids_to_names_dict[
+                            str(previously_posted_value["scan_report_field"])
+                        ]
+                    )
                 )  # dict of values, will default to None if field not found in table
             else:
                 vocab_id = None
@@ -757,9 +763,7 @@ async def process_values_from_sheet(
                 for returned_concept in concept_vocab_content:
                     # print("comparing", returned_concept, entry)
                     count += 1
-                    if str(entry["value"]) == str(
-                            returned_concept["concept_code"]
-                    ):
+                    if str(entry["value"]) == str(returned_concept["concept_code"]):
                         print(
                             "matched",
                             entry["value"],
@@ -782,7 +786,9 @@ async def process_values_from_sheet(
             entries_to_find_standard_concept = []
             for entry in entries_split_by_vocab[vocab]:
                 if entry["concept_id"] != -1 and entry["standard_concept"] != "S":
-                    logger.debug(f"looking for standard concept for nonstandard {entry['concept_id']}")
+                    logger.debug(
+                        f"looking for standard concept for nonstandard {entry['concept_id']}"
+                    )
                     entries_to_find_standard_concept.append(entry)
 
                     # print(f"this entry is {entry}")
@@ -821,7 +827,8 @@ async def process_values_from_sheet(
             "content_type": 17,
             "creation_type": "V",
         }
-        for concept in details_of_posted_values if concept["concept_id"] != -1
+        for concept in details_of_posted_values
+        if concept["concept_id"] != -1
     ]
 
     # ------------------------------------

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -715,10 +715,11 @@ async def process_values_from_sheet(
             concept_vocab_response = []
 
             for page_of_values in paginated_values_in_this_vocab:
-                # print(f"{concepts_to_get_item=}")
+                page_of_values_to_get = ",".join(map(str, page_of_values))
+
                 get_concept_vocab_response = requests.get(
                     f"{API_URL}omop/conceptsfilter/?concept_code__in="
-                    f"{','.join(page_of_values)}&vocabulary_id__in"
+                    f"{page_of_values_to_get}&vocabulary_id__in"
                     f"={vocab}",
                     headers=HEADERS,
                 )

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -274,11 +274,12 @@ def reuse_existing_field_concepts(new_fields_map, content_type):
     existing_field_name_to_field_and_concept_id_map = {}
     for item in new_fields_full_details:
         name = item["name"]
-        mappings_matching_field_name = [
-            mapping
-            for mapping in existing_mappings_to_consider
-            if mapping["name"] == name
-        ]
+        mappings_matching_field_name = list(
+            filter(
+                lambda mapping: mapping["name"] == name, existing_mappings_to_consider
+            )
+        )
+
         target_concept_ids = {
             mapping["concept"] for mapping in mappings_matching_field_name
         }
@@ -441,13 +442,15 @@ def reuse_existing_value_concepts(new_values_map, content_type):
         name = item["name"]
         description = item["description"]
         field_name = item["field_name"]
-        mappings_matching_value_name = [
-            mapping
-            for mapping in existing_mappings_to_consider
-            if mapping["name"] == name
-            and mapping["description"] == description
-            and mapping["field_name"] == field_name
-        ]
+        mappings_matching_value_name = list(
+            filter(
+                lambda mapping: mapping["name"] == name
+                and mapping["description"] == description
+                and mapping["field_name"] == field_name,
+                existing_mappings_to_consider,
+            )
+        )
+
         target_concept_ids = {
             mapping["concept"] for mapping in mappings_matching_value_name
         }

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -829,12 +829,12 @@ async def process_values_from_sheet(
     logger.debug(f"chunked concepts list len: {len(chunked_concept_id_data)}")
 
     await post_chunks(
-            chunked_concept_id_data,
-            "scanreportconcepts",
-            "concept",
-            table_name=current_table_name,
-            scan_report_id=scan_report_id,
-        )
+        chunked_concept_id_data,
+        "scanreportconcepts",
+        "concept",
+        table_name=current_table_name,
+        scan_report_id=scan_report_id,
+    )
 
     logger.info("POST concepts all finished")
     logger.debug(f"RAM memory % used: {psutil.virtual_memory()}")
@@ -1183,7 +1183,8 @@ def main(msg: func.QueueMessage):
     # and ScanReportValues associated to that table, then continue down the
     # list of fields in tables until all fields in all tables have been
     # processed (along with their ScanReportValues).
-    asyncio.run(process_all_fields_and_values(
+    asyncio.run(
+        process_all_fields_and_values(
             fo_ws,
             table_name_to_id_map,
             wb,

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -73,12 +73,10 @@ async def post_chunks(chunked_data, endpoint, text_string, table_name, scan_repo
     timeout = httpx.Timeout(60.0, connect=30.0)
 
     for chunk_no, chunk in enumerate(chunked_data):
-        logger.debug(f"chunk {chunk_no}")
         async with httpx.AsyncClient(timeout=timeout) as client:
             tasks = []
             page_lengths = []
             for page_no, page in enumerate(chunk):
-                logger.debug(f"chunk {chunk_no} page {page_no}")
                 # POST chunked data to endpoint
                 tasks.append(
                     asyncio.ensure_future(
@@ -92,7 +90,6 @@ async def post_chunks(chunked_data, endpoint, text_string, table_name, scan_repo
                 page_lengths.append(len(page))
 
             responses = await asyncio.gather(*tasks)
-            logger.debug(f"{responses}")
 
         for response, page_length in zip(responses, page_lengths):
             logger.info(
@@ -555,9 +552,6 @@ async def process_values_from_sheet(
     fieldids_to_names_dict,
     scan_report_id,
 ):
-    # print("WORKING ON", sheet.title)
-    # Reset list for values
-    value_entries_to_post = []
     # Get (col_name, value, frequency) for each field in the table
     fieldname_value_freq_dict = process_scan_report_sheet_table(sheet)
 
@@ -613,8 +607,6 @@ async def process_values_from_sheet(
         }
         for entry in values_details
     ]
-
-    # print(value_entries_to_post)
 
     # --------------------------------------------------------------------------------
     # Chunk the SRValues data ready for upload, and then upload via the endpoint.

--- a/ProcessQueue/__init__.py
+++ b/ProcessQueue/__init__.py
@@ -770,8 +770,10 @@ async def process_values_from_sheet(
             for entry in entries_split_by_vocab[vocab]:
                 if entry["concept_id"] != -1 and entry["standard_concept"] != "S":
                     entries_to_find_standard_concept.append(entry)
-            logger.debug(f"finished selecting nonstandard concepts - selected "
-                         f"{len(entries_to_find_standard_concept)}")
+            logger.debug(
+                f"finished selecting nonstandard concepts - selected "
+                f"{len(entries_to_find_standard_concept)}"
+            )
 
             batched_standard_concepts_map = omop_helpers.find_standard_concept_batch(
                 entries_to_find_standard_concept

--- a/ProcessQueue/helpers.py
+++ b/ProcessQueue/helpers.py
@@ -119,3 +119,14 @@ def paginate(entries, max_chars=None):
         paginated_entries.append(this_page)
 
     return paginated_entries
+
+
+def get_by_concept_id(list_of_dicts: list, concept_id: str):
+    """
+    Given a list of dicts, return the dict from the list which
+    contains the concept_id supplied
+    """
+    for item in list_of_dicts:
+        if str(item["concept_id"]) == str(concept_id):
+            return item
+    return None

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -165,9 +165,11 @@ class ConceptRelationshipFilterViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = ConceptRelationship.objects.all()
     serializer_class = ConceptRelationshipSerializer
     filter_backends = [DjangoFilterBackend]
-    filterset_fields = {"concept_id_1": ["in", "exact"],
-                        "concept_id_2": ["in", "exact"],
-                        "relationship_id": ["in", "exact"]}
+    filterset_fields = {
+        "concept_id_1": ["in", "exact"],
+        "concept_id_2": ["in", "exact"],
+        "relationship_id": ["in", "exact"],
+    }
 
 
 class ConceptAncestorViewSet(viewsets.ReadOnlyModelViewSet):

--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -165,7 +165,9 @@ class ConceptRelationshipFilterViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = ConceptRelationship.objects.all()
     serializer_class = ConceptRelationshipSerializer
     filter_backends = [DjangoFilterBackend]
-    filterset_fields = ["concept_id_1", "concept_id_2", "relationship_id"]
+    filterset_fields = {"concept_id_1": ["in", "exact"],
+                        "concept_id_2": ["in", "exact"],
+                        "relationship_id": ["in", "exact"]}
 
 
 class ConceptAncestorViewSet(viewsets.ReadOnlyModelViewSet):

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,9 @@ Please append a line to the changelog for each change made.
 
 ### Improvements
 * Improved error message reporting while checking the structure of uploaded files for consistency.
-
+* Rewritten values upload enables much faster uploads and vocabulary mapping.
+* Rewritten standard concept matching now enables a single nonstandard concept to be matched to more than one 
+standard concept.
 ### Bugfixes
 
 

--- a/shared_code/omop_helpers.py
+++ b/shared_code/omop_helpers.py
@@ -19,7 +19,8 @@ def find_standard_concept(source_concept):
 
     concept_relation = concept_relation.json()
     if len(concept_relation) == 0:
-        raise RuntimeWarning("concept_relation is empty in vocab")
+        return {"concept_id": -1}
+        # raise RuntimeWarning("concept_relation is empty in vocab")
     concept_relation = concept_relation[0]
 
     if concept_relation["concept_id_2"] != concept_relation["concept_id_1"]:

--- a/shared_code/omop_helpers.py
+++ b/shared_code/omop_helpers.py
@@ -58,11 +58,13 @@ def find_standard_concept_batch(source_concepts: list):
 
     # Find those concepts with a "trail" to follow, that is, those which have
     # differing concept_id_1/2.
-    filtered_concept_relations = [
-        concept_relation
-        for concept_relation in concept_relations
-        if concept_relation["concept_id_2"] != concept_relation["concept_id_1"]
-    ]
+    filtered_concept_relations = list(
+        filter(
+            lambda concept_relation: concept_relation["concept_id_2"]
+            != concept_relation["concept_id_1"],
+            concept_relations,
+        )
+    )
 
     paginated_concept_id_2s = helpers.paginate(
         (str(relation["concept_id_2"]) for relation in filtered_concept_relations),

--- a/shared_code/omop_helpers.py
+++ b/shared_code/omop_helpers.py
@@ -36,15 +36,12 @@ def find_standard_concept_batch(source_concepts: list):
     if len(source_concepts) == 0:
         return {}
 
-    # logger.debug(
-    #     f"getting "
-    #     f"{','.join(str(source_concept['concept_id']) for source_concept in source_concepts)}"
-    # )
+    # Paginate the source concepts
     paginated_source_concepts = helpers.paginate(
         (str(source_concept["concept_id"]) for source_concept in source_concepts),
         max_chars=max_chars_for_get,
     )
-    # TODO: Needs pagination
+
     # Get "Maps to" relations of all source concepts supplied
     concept_relations_response = []
     for page in paginated_source_concepts:
@@ -58,27 +55,22 @@ def find_standard_concept_batch(source_concepts: list):
         concept_relations_response.append(get_concept_relations_response.json())
     concept_relations = helpers.flatten(concept_relations_response)
 
-    logger.debug("got CRel")
-
     # Find those concepts with a "trail" to follow, that is, those which have
     # differing concept_id_1/2.
-    non_last_target_concepts = [
+    filtered_concept_relations = [
         concept_relation
         for concept_relation in concept_relations
         if concept_relation["concept_id_2"] != concept_relation["concept_id_1"]
     ]
 
-    logger.debug("non_last_targets selected")
-
     paginated_concept_id_2s = helpers.paginate(
-        (str(relation["concept_id_2"]) for relation in non_last_target_concepts),
+        (str(relation["concept_id_2"]) for relation in filtered_concept_relations),
         max_chars=max_chars_for_get,
     )
     # Send all of those to conceptfilter again to check they are standard.
     concepts = []
     for page in paginated_concept_id_2s:
         concept_id_2s_to_get = ",".join(map(str, page))
-
         get_concepts = requests.get(
             url=f"{api_url}omop/conceptsfilter/?concept_id__in={concept_id_2s_to_get}",
             headers=api_header,
@@ -92,32 +84,13 @@ def find_standard_concept_batch(source_concepts: list):
     # Filter by those concepts relationships where the second concept_id is standard
     # Now combine the pairs so that each pair is of type tuple(str, list(str))
     combined_pairs = defaultdict(list)
-    for relationship in non_last_target_concepts:
+    for relationship in filtered_concept_relations:
         if concept_details[relationship["concept_id_2"]] == "S":
             combined_pairs[relationship["concept_id_1"]].append(
                 relationship["concept_id_2"]
             )
 
     return combined_pairs
-    # if len(concept_relation) == 0:
-    #     return {"concept_id": -1}
-    #     # raise RuntimeWarning("concept_relation is empty in vocab")
-    # concept_relation = concept_relation[0]
-    #
-    # if concept_relation["concept_id_2"] != concept_relation["concept_id_1"]:
-    #     concept = requests.get(
-    #         url=api_url + "omop/conceptsfilter",
-    #         headers=api_header,
-    #         params={"concept_id": concept_relation["concept_id_2"]},
-    #     )
-    #     concept = concept.json()
-    #     if len(concept) == 0:
-    #         raise RuntimeWarning("concept filter returned empty")
-    #     concept = concept[0]
-    #     return concept
-    # else:
-    #     # may need some warning if this ever happens?
-    #     return source_concept
 
 
 def find_standard_concept(source_concept):

--- a/shared_code/omop_helpers.py
+++ b/shared_code/omop_helpers.py
@@ -40,9 +40,10 @@ def find_standard_concept_batch(source_concepts: list):
     #     f"getting "
     #     f"{','.join(str(source_concept['concept_id']) for source_concept in source_concepts)}"
     # )
-    paginated_source_concepts = helpers.paginate((str(source_concept["concept_id"])
-                                                 for source_concept in source_concepts),
-                                                 max_chars=max_chars_for_get)
+    paginated_source_concepts = helpers.paginate(
+        (str(source_concept["concept_id"]) for source_concept in source_concepts),
+        max_chars=max_chars_for_get,
+    )
     # TODO: Needs pagination
     # Get "Maps to" relations of all source concepts supplied
     concept_relations_response = []
@@ -50,9 +51,7 @@ def find_standard_concept_batch(source_concepts: list):
         get_concept_relations_response = requests.get(
             url=api_url
             + "omop/conceptrelationshipfilter/?concept_id_1__in="
-            + ",".join(
-                str(concept_id) for concept_id in page
-            )
+            + ",".join(str(concept_id) for concept_id in page)
             + "&relationship_id=Maps to",
             headers=api_header,
         )
@@ -63,14 +62,18 @@ def find_standard_concept_batch(source_concepts: list):
 
     # Find those concepts with a "trail" to follow, that is, those which have
     # differing concept_id_1/2.
-    non_last_target_concepts = [concept_relation for concept_relation in concept_relations
-        if concept_relation["concept_id_2"] != concept_relation["concept_id_1"]]
+    non_last_target_concepts = [
+        concept_relation
+        for concept_relation in concept_relations
+        if concept_relation["concept_id_2"] != concept_relation["concept_id_1"]
+    ]
 
     logger.debug("non_last_targets selected")
 
-    paginated_concept_id_2s = helpers.paginate((str(relation["concept_id_2"])
-                                                 for relation in non_last_target_concepts),
-                                                 max_chars=max_chars_for_get)
+    paginated_concept_id_2s = helpers.paginate(
+        (str(relation["concept_id_2"]) for relation in non_last_target_concepts),
+        max_chars=max_chars_for_get,
+    )
     # Send all of those to conceptfilter again to check they are standard.
     concepts = []
     for page in paginated_concept_id_2s:
@@ -91,7 +94,9 @@ def find_standard_concept_batch(source_concepts: list):
     combined_pairs = defaultdict(list)
     for relationship in non_last_target_concepts:
         if concept_details[relationship["concept_id_2"]] == "S":
-            combined_pairs[relationship["concept_id_1"]].append(relationship["concept_id_2"])
+            combined_pairs[relationship["concept_id_1"]].append(
+                relationship["concept_id_2"]
+            )
 
     return combined_pairs
     # if len(concept_relation) == 0:

--- a/shared_code/omop_helpers.py
+++ b/shared_code/omop_helpers.py
@@ -1,4 +1,6 @@
-import requests, os, time
+import os
+import time
+import requests
 import logging
 from collections import defaultdict
 from ProcessQueue import helpers

--- a/shared_code/omop_helpers.py
+++ b/shared_code/omop_helpers.py
@@ -45,11 +45,10 @@ def find_standard_concept_batch(source_concepts: list):
     # Get "Maps to" relations of all source concepts supplied
     concept_relations_response = []
     for page in paginated_source_concepts:
+        page_of_concept_ids_to_get = ",".join(map(str, page))
         get_concept_relations_response = requests.get(
-            url=api_url
-            + "omop/conceptrelationshipfilter/?concept_id_1__in="
-            + ",".join(str(concept_id) for concept_id in page)
-            + "&relationship_id=Maps to",
+            url=f"{api_url}omop/conceptrelationshipfilter/?concept_id_1__in="
+            + f"{page_of_concept_ids_to_get}&relationship_id=Maps to",
             headers=api_header,
         )
         concept_relations_response.append(get_concept_relations_response.json())

--- a/shared_code/omop_helpers.py
+++ b/shared_code/omop_helpers.py
@@ -1,9 +1,118 @@
 import requests, os, time
 import logging
+from collections import defaultdict
+from ProcessQueue import helpers
 
 api_url = os.environ.get("APP_URL") + "api/"
 api_header = {"Authorization": "Token {}".format(os.environ.get("AZ_FUNCTION_KEY"))}
 logger = logging.getLogger("test_logger")
+
+max_chars_for_get = 2000
+
+
+def find_standard_concept_batch(source_concepts: list):
+    """
+    Given a list of dictionaries, each of which contains a 'concept_id' entry,
+    return a dictionary mapping from the original concept_ids to all standard
+    concepts it maps to via ConceptRelationship.
+
+    example:
+    - input
+      [{'id': 2575531, 'value': 'V68.0', ..., 'frequency': 2000,
+        'conceptID': -1, 'vocabulary_id': 'ICD9CM', 'concept_id': '45890989',
+        'standard_concept': 'None'},
+       {'id': 2575530, 'value': '804.35', ..., 'frequency': 1000,
+        'conceptID': -1, 'vocabulary_id': 'ICD9CM', 'concept_id': '44829331',
+        'standard_concept': 'None'}
+       ]
+
+    - output
+      defaultdict(<class 'list'>, {44829331: [380844, 4302223, 4307254, 42872561],
+                                   45890989: [4148832]}
+                  )
+    """
+    logger.debug("find_standard_concept_batch()")
+    # Exit early rather than having to handle this case in later code.
+    if len(source_concepts) == 0:
+        return {}
+
+    # logger.debug(
+    #     f"getting "
+    #     f"{','.join(str(source_concept['concept_id']) for source_concept in source_concepts)}"
+    # )
+    paginated_source_concepts = helpers.paginate((str(source_concept["concept_id"])
+                                                 for source_concept in source_concepts),
+                                                 max_chars=max_chars_for_get)
+    # TODO: Needs pagination
+    # Get "Maps to" relations of all source concepts supplied
+    concept_relations_response = []
+    for page in paginated_source_concepts:
+        get_concept_relations_response = requests.get(
+            url=api_url
+            + "omop/conceptrelationshipfilter/?concept_id_1__in="
+            + ",".join(
+                str(concept_id) for concept_id in page
+            )
+            + "&relationship_id=Maps to",
+            headers=api_header,
+        )
+        concept_relations_response.append(get_concept_relations_response.json())
+    concept_relations = helpers.flatten(concept_relations_response)
+
+    logger.debug("got CRel")
+
+    # Find those concepts with a "trail" to follow, that is, those which have
+    # differing concept_id_1/2.
+    non_last_target_concepts = [concept_relation for concept_relation in concept_relations
+        if concept_relation["concept_id_2"] != concept_relation["concept_id_1"]]
+
+    logger.debug("non_last_targets selected")
+
+    paginated_concept_id_2s = helpers.paginate((str(relation["concept_id_2"])
+                                                 for relation in non_last_target_concepts),
+                                                 max_chars=max_chars_for_get)
+    # Send all of those to conceptfilter again to check they are standard.
+    concepts = []
+    for page in paginated_concept_id_2s:
+        concept_id_2s_to_get = ",".join(map(str, page))
+
+        get_concepts = requests.get(
+            url=f"{api_url}omop/conceptsfilter/?concept_id__in={concept_id_2s_to_get}",
+            headers=api_header,
+        )
+        concepts.append(get_concepts.json())
+    concepts = helpers.flatten(concepts)
+    logger.debug("concepts got")
+
+    concept_details = {a["concept_id"]: a["standard_concept"] for a in concepts}
+
+    # Filter by those concepts relationships where the second concept_id is standard
+    # Now combine the pairs so that each pair is of type tuple(str, list(str))
+    combined_pairs = defaultdict(list)
+    for relationship in non_last_target_concepts:
+        if concept_details[relationship["concept_id_2"]] == "S":
+            combined_pairs[relationship["concept_id_1"]].append(relationship["concept_id_2"])
+
+    return combined_pairs
+    # if len(concept_relation) == 0:
+    #     return {"concept_id": -1}
+    #     # raise RuntimeWarning("concept_relation is empty in vocab")
+    # concept_relation = concept_relation[0]
+    #
+    # if concept_relation["concept_id_2"] != concept_relation["concept_id_1"]:
+    #     concept = requests.get(
+    #         url=api_url + "omop/conceptsfilter",
+    #         headers=api_header,
+    #         params={"concept_id": concept_relation["concept_id_2"]},
+    #     )
+    #     concept = concept.json()
+    #     if len(concept) == 0:
+    #         raise RuntimeWarning("concept filter returned empty")
+    #     concept = concept[0]
+    #     return concept
+    # else:
+    #     # may need some warning if this ever happens?
+    #     return source_concept
 
 
 def find_standard_concept(source_concept):


### PR DESCRIPTION
This PR rewrites the way vocabulary mapping is done in `ProcessQueue`. This requires a rewrite of a considerable chunk of code in order to enable batch processing and remove the need for PATCHing that was previously used.

It also now supports mapping a single non-standard concept to more than one standard concept.

# Changes


# Migrations

None, though I need to check whether the additional vocabularies have been added to test and prod DBs.

# Screenshots
NA

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
