### PR TITLE
Make 'Table Overview' and '_' sheets optional

### DIFF
--- a/api/mapping/forms.py
+++ b/api/mapping/forms.py
@@ -210,21 +210,25 @@ class ScanReportForm(forms.Form):
         # on to comparing its contents to the sheets
 
         # Check tables in FO match supplied sheets
-        table_names = list(
-            set(
-                cell.value
-                for cell in fo_ws["A"][1:]
-                if (cell.value != "" and cell.value is not None)
-            )
+        table_names = set(
+            cell.value
+            for cell in fo_ws["A"][1:]
+            if (cell.value != "" and cell.value is not None)
         )
-        # Drop "Table Overview" and "_" sheets if present, as these are never used.
+        # Drop "Table Overview" and "_" sheetnames if present, as these are never used.
         table_names.difference_update(["Table Overview", "_"])
 
         # "Field Overview" is the only required sheet that is not a table name.
-        expected_sheetnames = table_names + ["Field Overview"]
-        if sorted(wb.sheetnames) != sorted(expected_sheetnames):
-            sheets_only = set(wb.sheetnames).difference(expected_sheetnames)
-            fo_only = set(expected_sheetnames).difference(wb.sheetnames)
+        expected_sheetnames = list(table_names) + ["Field Overview"]
+
+        # Get names of sheet from workbook
+        actual_sheetnames = set(wb.sheetnames)
+        # Drop "Table Overview" and "_" sheetnames if present, as these are never used.
+        actual_sheetnames.difference_update(["Table Overview", "_"])
+
+        if sorted(actual_sheetnames) != sorted(expected_sheetnames):
+            sheets_only = set(actual_sheetnames).difference(expected_sheetnames)
+            fo_only = set(expected_sheetnames).difference(actual_sheetnames)
             errors.append(
                 ValidationError(
                     "Tables in Field Overview sheet do not "

--- a/api/mapping/forms.py
+++ b/api/mapping/forms.py
@@ -217,14 +217,18 @@ class ScanReportForm(forms.Form):
                 if (cell.value != "" and cell.value is not None)
             )
         )
-        expected_sheetnames = table_names + ["Field Overview", "Table Overview", "_"]
+        # Drop "Table Overview" and "_" sheets if present, as these are never used.
+        table_names.difference_update(["Table Overview", "_"])
+
+        # "Field Overview" is the only required sheet that is not a table name.
+        expected_sheetnames = table_names + ["Field Overview"]
         if sorted(wb.sheetnames) != sorted(expected_sheetnames):
             sheets_only = set(wb.sheetnames).difference(expected_sheetnames)
             fo_only = set(expected_sheetnames).difference(wb.sheetnames)
             errors.append(
                 ValidationError(
-                    f"Tables in Field Overview sheet do not "
-                    f"match the sheets supplied."
+                    "Tables in Field Overview sheet do not "
+                    "match the sheets supplied."
                 )
             )
             if sheets_only:


### PR DESCRIPTION
# Changes

- Consistency checks which run on Scan Report file ignore the presence of sheets entitled "Table Overview" or "_". These are often present by default from WhiteRabbit output, but we do not use them in our uploads. To avoid the need for manually-curated SR files to include these, the code now ignores their presence. Of course, if you have a table in your dataset called "Table Overview" then this will break, but I expect WhiteRabbit might do something odd in that situation anyway.

# Migrations

NA

# Screenshots

NA

# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
