### PR TITLE
Paginate calls to mappingrulesfilter.

### DIFF
--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -809,7 +809,10 @@ class MappingRuleFilterViewSet(viewsets.ModelViewSet):
     queryset = MappingRule.objects.all()
     serializer_class = MappingRuleSerializer
     filter_backends = [DjangoFilterBackend]
-    filterset_fields = ["scan_report"]
+    filterset_fields = {
+        "scan_report": ["in", "exact"],
+        "concept": ["in", "exact"],
+    }
 
 
 class ScanReportValueViewSet(viewsets.ModelViewSet):

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,15 @@
 
 Please append a line to the changelog for each change made.
 
+## v2.0.6
+### New features
+
+### Improvements
+- Removed an unnecessary API call that was badly affecting large Values pages. This greatly improves that page's loading time.
+
+### Bugfixes
+
+
 ## v2.0.5
 ### New features
 


### PR DESCRIPTION
# Changes

This PR removes an unnecessary call to `mappingrulesfilter/`, and adds `concept` as a filterset_field in that endpoint.

# Migrations

NA

# Screenshots

# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
