### PR TITLE
Paginate calls to mappingrulesfilter.

### DIFF
--- a/react-client-app/src/api/values.js
+++ b/react-client-app/src/api/values.js
@@ -145,9 +145,15 @@ const getValuesScanReportConcepts = async (values,contentType,scanReportsRef={},
         const conceptPromiseResults = await Promise.all(conceptPromises)
         const omopConcepts = [].concat.apply([], conceptPromiseResults)
 
-        // this query may need to be paginated. Also the endpoint does not actually exist so it is returning
+        // the endpoint does not actually exist so it is returning
         // all the mapping rules at the moment which works but needs to be fixed
-        const mappingRules = await useGet(`/mappingrulesfilter/?concepts__in=${scanreportconcepts.map(item=>item.id).join()}`)
+        const scanreportconceptIds = chunkIds(scanreportconcepts.map(item => item.id))
+        const scanreportconceptPromises = []
+        for (let i = 0; i < scanreportconceptIds.length; i++) {
+            scanreportconceptPromises.push(useGet(`/mappingrulesfilter/?concepts__in=${scanreportconceptIds[i].join()}`))
+        }
+        const mappingRulesPromiseResult = await Promise.all(scanreportconceptPromises)
+        const mappingRules = [].concat.apply([], mappingRulesPromiseResult)
         scanreportconcepts = scanreportconcepts.map(element=>({...element,mappings:mappingRules.filter(el=>el.concept==element.id)}))
 
 


### PR DESCRIPTION
# Changes

Paginates a GET request in values.js for ScanReportConcepts. This caused 400 errors when too many ScanReportConcepts were requested on a single Values page.

# Migrations

NA

# Screenshots

Previously:
![image](https://user-images.githubusercontent.com/11610738/191760919-3f03eb9c-d988-499c-b605-1b818fbfbfce.png)

Now:
![image](https://user-images.githubusercontent.com/11610738/191760768-c1327734-9293-4658-b1b3-cae41ebdebc0.png)


# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
