### PR TITLE
Merge dev to test 2.0.6

### DIFF
--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -809,7 +809,10 @@ class MappingRuleFilterViewSet(viewsets.ModelViewSet):
     queryset = MappingRule.objects.all()
     serializer_class = MappingRuleSerializer
     filter_backends = [DjangoFilterBackend]
-    filterset_fields = ["scan_report"]
+    filterset_fields = {
+        "scan_report": ["in", "exact"],
+        "concept": ["in", "exact"],
+    }
 
 
 class ScanReportValueViewSet(viewsets.ModelViewSet):

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,15 @@
 
 Please append a line to the changelog for each change made.
 
+## v2.0.6
+### New features
+
+### Improvements
+- Removed an unnecessary API call that was badly affecting large Values pages. This greatly improves that page's loading time.
+
+### Bugfixes
+
+
 ## v2.0.5
 ### New features
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,13 +2,13 @@
 
 Please append a line to the changelog for each change made.
 
-## v2.0.5-beta
+## v2.0.5
 ### New features
 
 ### Improvements
 
 ### Bugfixes
-
+- Fixed an issue where too many concepts in a single page would result in a 400 error.
 
 ## v2.0.4
 ### New features

--- a/react-client-app/src/api/values.js
+++ b/react-client-app/src/api/values.js
@@ -145,9 +145,15 @@ const getValuesScanReportConcepts = async (values,contentType,scanReportsRef={},
         const conceptPromiseResults = await Promise.all(conceptPromises)
         const omopConcepts = [].concat.apply([], conceptPromiseResults)
 
-        // this query may need to be paginated. Also the endpoint does not actually exist so it is returning
+        // the endpoint does not actually exist so it is returning
         // all the mapping rules at the moment which works but needs to be fixed
-        const mappingRules = await useGet(`/mappingrulesfilter/?concepts__in=${scanreportconcepts.map(item=>item.id).join()}`)
+        const scanreportconceptIds = chunkIds(scanreportconcepts.map(item => item.id))
+        const scanreportconceptPromises = []
+        for (let i = 0; i < scanreportconceptIds.length; i++) {
+            scanreportconceptPromises.push(useGet(`/mappingrulesfilter/?concepts__in=${scanreportconceptIds[i].join()}`))
+        }
+        const mappingRulesPromiseResult = await Promise.all(scanreportconceptPromises)
+        const mappingRules = [].concat.apply([], mappingRulesPromiseResult)
         scanreportconcepts = scanreportconcepts.map(element=>({...element,mappings:mappingRules.filter(el=>el.concept==element.id)}))
 
 


### PR DESCRIPTION
# Release candidate for 2.0.6

Single bugfix release.

This PR removes an unnecessary call to mappingrulesfilter/, and adds concept as a filterset_field in that endpoint.

