### PR TITLE
Move call to analyse/ to only run after 'Analyse Rules' button is pressed

### DIFF
--- a/react-client-app/src/components/ConceptAnalysis.jsx
+++ b/react-client-app/src/components/ConceptAnalysis.jsx
@@ -1,7 +1,28 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import AnalysisTbl from './AnalysisTbl'
+import { useGet } from '../api/values'
 
-function ConceptAnalysis({ data }) {
+function ConceptAnalysis({ scan_report_id }) {
+
+    const [data, setData] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [loadingMessage, setLoadingMessage] = useState("");
+    const [error, setError] = useState(undefined);
+
+
+    useEffect(() => {
+        useGet(`/analyse/${scan_report_id}/`).then(res => {
+            setData(res.data)
+            setLoading(false);
+            setLoadingMessage("");
+        })
+            .catch(err => {
+                setLoading(false);
+                setLoadingMessage("");
+                setError("An error has occurred while fetching the rules")
+            })
+    }, []);
+
 
     return (
         <div>

--- a/react-client-app/src/components/MappingTbl.jsx
+++ b/react-client-app/src/components/MappingTbl.jsx
@@ -26,7 +26,6 @@ const MappingTbl = (props) => {
     const scan_report_id = pathArray[pathArray.length - 3]
     const scanReportName = useRef(null);
     const [values, setValues] = useState([]);
-    const [data, setData] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(undefined);
     const [loadingMessage, setLoadingMessage] = useState("");
@@ -320,21 +319,6 @@ const MappingTbl = (props) => {
 
     }
 
-    useEffect(() => {
-        useGet(`/analyse/${scan_report_id}`).then(res => { // not sure if this needs a / on the end or not as it's an undocumented endpoint
-            setData(res.data)
-            setLoading(false);
-            setLoadingMessage("");
-
-        })
-            .catch(err => {
-                setLoading(false);
-                setLoadingMessage("");
-                setError("An error has occured while fetching the rules")
-            })
-
-    }, []);
-
     if (loading) {
         //Render Loading State
         return (
@@ -354,7 +338,7 @@ const MappingTbl = (props) => {
                     destinationTableFilter={destinationTableFilter} sourceTableFilter={sourceTableFilter} scanReportId={scan_report_id} />
             </MappingModal>
             <AnalysisModal isOpenAnalyse={isOpenAnalyse} onOpenAnalyse={onOpenAnalyse} onCloseAnalyse={onCloseAnalyse}>
-                <ConceptAnalysis data={data} />
+                <ConceptAnalysis scan_report_id={scan_report_id} />
             </AnalysisModal>
             <CCBreadcrumbBar>
                 <Link href={"/"}>Home</Link>


### PR DESCRIPTION
This has the benefit that this will not trigger an error in the largest SRs when viewing the mapping rules page. The downside is that analysis does not load in the background, making the button seem less responsive.

# Changes

- Moved `analyse/` call into `ConceptAnalysis` function. `ConceptAnalysis()` function parameter is changed to take `scan_report_id` rather than `data`.

# Migrations

NA

# Screenshots

NA

# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
