### PR TITLE
Add buttons to Field and Value pages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ Please append a line to the changelog for each change made.
 ### Improvements
 - Improved consistency of presentation of key terms on dashboard
 - Analysis of rules moved to trigger only after 'Analyse Rules' button is pressed. This has the benefit that this will not trigger an error in the largest SRs when viewing the mapping rules page (which was something we had seen, which blocks the ability to use the mapping rules page). The downside is that analysis does not load in the background, making the button seem less responsive.
+- Added 'Edit Table', 'Scan Report Details' and 'Mapping Rules' buttons to top of Fields and Values pages.
 
 ### Bugfixes
 - Corrected headings in a table on the dashboard

--- a/react-client-app/src/components/FieldsTbl.jsx
+++ b/react-client-app/src/components/FieldsTbl.jsx
@@ -116,6 +116,20 @@ const FieldsTbl = (props) => {
                     <Link href={`/scanreports/${scanReportTable.current.scan_report}/tables/${scanReportTableId}/`}>{scanReportTable.current.name}</Link>
                 </CCBreadcrumbBar>
                 <PageHeading text={"Fields"} />
+                <Flex my="10px">
+                    <HStack>
+                        <Link href={"/scanreports/" + scanReportId + "/details/"}>
+                            <Button variant="blue" my="10px">Scan Report Details</Button>
+                        </Link>
+                        <Link href={"/scanreports/" + scanReportId + "/mapping_rules/"}>
+                            <Button isDisabled={mappingButtonDisabled} variant="blue" my="10px">Go to Rules</Button>
+                        </Link>
+                        {window.canEdit && <Link href={"/scanreports/" + scanReportId + "/tables/" + scanReportTableId + "/update/"}>
+                            <Button variant="blue" my="10px">Edit Table</Button>
+                        </Link>
+                        }
+                    </HStack>
+                </Flex>
                 {isOpen &&
                     <ScaleFade initialScale={0.9} in={isOpen}>
                         <ToastAlert hide={onClose} title={alert.title} status={alert.status} description={alert.description} />
@@ -201,7 +215,6 @@ const FieldsTbl = (props) => {
                         }
                     </Tbody>
                 </Table>
-                <Link href={"/scanreports/" + scanReportTable.current.scan_report + "/mapping_rules/"}><Button isDisabled={mappingButtonDisabled} variant="blue" my="10px">Go to Rules</Button></Link>
             </div>
         )
 

--- a/react-client-app/src/components/ValuesTbl.jsx
+++ b/react-client-app/src/components/ValuesTbl.jsx
@@ -114,6 +114,20 @@ const ValuesTbl = (props) => {
                     <Link href={`/scanreports/${scanReportTable.current.scan_report}/tables/${scanReportTable.current.id}/fields/${scanReportField.current.id}/`}>{scanReportField.current.name}</Link>
                 </CCBreadcrumbBar>
                 <PageHeading text={"Values"} />
+                <Flex my="10px">
+                    <HStack>
+                        <Link href={"/scanreports/" + scanReportId + "/details/"}>
+                            <Button variant="blue" my="10px">Scan Report Details</Button>
+                        </Link>
+                        <Link href={"/scanreports/" + scanReportId + "/mapping_rules/"}>
+                            <Button isDisabled={mappingButtonDisabled} variant="blue" my="10px">Go to Rules</Button>
+                        </Link>
+                        {window.canEdit && <Link href={"/scanreports/" + scanReportId + "/tables/" + scanReportTable.current.id + "/update/"}>
+                            <Button variant="blue" my="10px">Edit Table</Button>
+                        </Link>
+                        }
+                    </HStack>
+                </Flex>
                 {isOpen &&
                     <ScaleFade initialScale={0.9} in={isOpen}>
                         <ToastAlert hide={onClose} title={alert.title} status={alert.status} description={alert.description} />
@@ -198,7 +212,6 @@ const ValuesTbl = (props) => {
                         }
                     </Tbody>
                 </Table>
-                <Link href={"/scanreports/" + scanReportTable.current.scan_report + "/mapping_rules/"}><Button isDisabled={mappingButtonDisabled} variant="blue" my="10px">Go to Rules</Button></Link>
             </div>
         )
 


### PR DESCRIPTION
# Changes

Add 'Edit Table', 'Scan Report Details' and 'Mapping Rules' buttons to top of Fields and Values pages

# Migrations

NA

# Screenshots

![image](https://user-images.githubusercontent.com/11610738/193306909-aa2b1573-aa51-471b-8135-064186768546.png)

![image](https://user-images.githubusercontent.com/11610738/193306973-024f7024-3646-4699-af13-68327ea76e43.png)

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
