### PR TITLE
Add 'New Scan Report Upload' in navbar dropdown.

### DIFF
--- a/api/templates/base.html
+++ b/api/templates/base.html
@@ -52,8 +52,13 @@
                 <li class="nav-item active">
                     <a class="nav-link" aria-current="page" href="{% url 'datasets' %}">Datasets</a>
                 </li>
-                <li class="nav-item active">
-                    <a class="nav-link" aria-current="page" href="{% url 'scan-report-list' %}">Scan Reports</a>
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" href="#">Scan Reports</a>
+				<ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+				<li><a class="dropdown-item" href="{% url 'scan-report-list' %}">Scan Reports</a></li>
+				<li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item" href="{% url 'scan-report-form' %}">New Scan Report Upload</a></li>
+                </ul>
                 </li>
                 <!--<li class="nav-item"><a class="nav-link">You are logged as: {{ user.username }}</a></li>-->
                 <li class="nav-item"><a class="nav-link" href="https://hdruk.github.io/CaRROT-Docs/" target="_blank">Documentation</a></li>

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ Please append a line to the changelog for each change made.
 - Improved consistency of presentation of key terms on dashboard
 - Analysis of rules moved to trigger only after 'Analyse Rules' button is pressed. This has the benefit that this will not trigger an error in the largest SRs when viewing the mapping rules page (which was something we had seen, which blocks the ability to use the mapping rules page). The downside is that analysis does not load in the background, making the button seem less responsive.
 - Added 'Edit Table', 'Scan Report Details' and 'Mapping Rules' buttons to top of Fields and Values pages.
+- Add dropdown to "Scan Reports" item in navbar. This makes the "New Scan Report" page accessible from all other pages.
 
 ### Bugfixes
 - Corrected headings in a table on the dashboard


### PR DESCRIPTION
# Changes

Add dropdown to "Scan Reports" item in navbar. This makes the "New Scan Report" page accessible from all other pages.

# Migrations

NA

# Screenshots

![image](https://user-images.githubusercontent.com/11610738/193315098-12fef891-2598-4ba2-a2f7-54cd176b3d93.png)

# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
