### PR TITLE
Remove get_context_data() from StructuralMappingTableListView

### DIFF
--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -1179,31 +1179,6 @@ class StructuralMappingTableListView(ListView):
 
         return qs
 
-    def get_context_data(self, **kwargs):
-        # Call the base implementation first to get a context
-        context = super().get_context_data(**kwargs)
-        pk = self.kwargs.get("pk")
-
-        scan_report = ScanReport.objects.get(pk=pk)
-
-        object_list = get_mapping_rules_list(self.get_queryset())
-        source_tables = list(set([x["source_table"].name for x in object_list]))
-
-        filtered_omop_table = self.kwargs.get("omop_table")
-        current_source_table = self.kwargs.get("source_table")
-
-        context.update(
-            {
-                "object_list": object_list,
-                "scan_report": scan_report,
-                "omop_tables": m_allowed_tables,
-                "source_tables": source_tables,
-                "filtered_omop_table": filtered_omop_table,
-                "current_source_table": current_source_table,
-            }
-        )
-        return context
-
 
 def modify_filename(filename, dt, rand):
     split_filename = os.path.splitext(str(filename))

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,15 @@
 
 Please append a line to the changelog for each change made.
 
+## v2.0.8-beta
+### New features
+
+### Improvements
+- Removed get_context_data() from StructuralMappingTableListView, as it was unused and added a large overhead when calling get_mapping_rules_list().
+
+### Bugfixes
+
+
 ## v2.0.7
 ### New features
 


### PR DESCRIPTION
# Changes

- Remove get_context_data() from StructuralMappingTableListView, as it was unused and added a large overhead when calling get_mapping_rules_list().

# Migrations

NA

# Screenshots

NA

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
