### PR TITLE
Remove duplicated ScanReportConcepts 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,15 @@
 
 Please append a line to the changelog for each change made.
 
+## v2.0.9
+### New features
+
+### Improvements
+- Removed duplicated ScanReportConcepts which are produced when non-standard codes are mapped via multiple routes to the same standard code.
+
+### Bugfixes
+
+
 ## v2.0.8
 ### New features
 

--- a/shared_code/omop_helpers.py
+++ b/shared_code/omop_helpers.py
@@ -2,7 +2,7 @@ import os
 import time
 import requests
 import logging
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from ProcessQueue import helpers
 
 api_url = os.environ.get("APP_URL") + "api/"
@@ -92,6 +92,12 @@ def find_standard_concept_batch(source_concepts: list):
             combined_pairs[relationship["concept_id_1"]].append(
                 relationship["concept_id_2"]
             )
+
+    # Remove duplicates from within each entry, by converting each to an Ordered Dict
+    # (the keys of which must be unique, and will preserve the order if that's
+    # important) and then back to a list.
+    for pair in combined_pairs:
+        combined_pairs[pair] = list(OrderedDict.fromkeys(combined_pairs[pair]))
 
     return combined_pairs
 


### PR DESCRIPTION
# Changes

Remove duplicated ScanReportConcepts which are produced when non-standard codes are mapped via multiple routes to the same standard code.

# Migrations

NA

# Screenshots

NA

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
