### PR TITLE
Add refresh_rules management command, and fix a bug

### DIFF
--- a/api/mapping/management/commands/refresh_mapping_rules.py
+++ b/api/mapping/management/commands/refresh_mapping_rules.py
@@ -1,0 +1,69 @@
+from django.core.management.base import BaseCommand
+from mapping.services_rules import (
+    remove_mapping_rules,
+    save_mapping_rules,
+    find_existing_scan_report_concepts,
+)
+from datetime import datetime
+
+
+class Command(BaseCommand):
+    help = "Refresh all the mapping rules associated to the supplied Scan Report. " \
+           "This can take a _very_ long time (hours) to execute for large numbers of " \
+           "ScanReportConcepts. It can also hang at random intervals. If this occurs " \
+           "(a single ScanReportConcept takes <2s to complete, so it's easy to spot " \
+           "when it hangs) then reboot the container, then comment out the " \
+           "'remove_mapping_rules' line below and set skip_first to skip n " \
+           "ScanReportConcepts."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--report-id", required=True, type=int)
+
+    def handle(self, *args, **options):
+        _id = int(options["report_id"])
+        request = None
+        # If restarting this command, comment out the "remove_mapping_rules" line to
+        # keep the previously generated rules, and then update the skip_first value
+        # below to avoid reprocessing all the first ScanReportConcepts which already
+        # have their mapping rules generated.
+        remove_mapping_rules(request, _id)
+        # get all associated ScanReportConcepts for this given ScanReport
+        ## this method can take a couple of minutes to execute
+        print("find_existing_scan_report_concepts")
+        all_associated_concepts = find_existing_scan_report_concepts(request, _id)
+        print("total SRConcepts:", len(all_associated_concepts))
+
+        # save all of them
+        nconcepts = 0
+        nbadconcepts = 0
+        start_time = datetime.utcnow()
+        n_concepts_total = len(all_associated_concepts)
+        print("total concepts to map: " + str(n_concepts_total))
+        skip_first = 0
+        n_concepts_total -= skip_first
+        for concept_index, concept in enumerate(all_associated_concepts[skip_first:]):
+            print("new concept " + str(concept_index) + " of " + str(n_concepts_total))
+            this_start_time = datetime.utcnow()
+            if save_mapping_rules(request, concept):
+                nconcepts += 1
+            else:
+                nbadconcepts += 1
+            latest_time = datetime.utcnow()
+            print("this concept took: " + str(latest_time - this_start_time))
+            average_period = (latest_time - start_time) / (concept_index + 1)
+            print("average time per concept so far: " + str(average_period))
+            # Print estimated end time, with a series of hashes on the end to mock a
+            # progress bar - makes it easier to immediately spot if it's hanging.
+            print(
+                "  estimated end time: "
+                + str(start_time + average_period * n_concepts_total)
+                + "#" * (concept_index % 10)
+            )
+
+        if nbadconcepts == 0:
+            print(request, f"Found and added rules for {nconcepts} existing concepts")
+        else:
+            print(
+                request,
+                f"Found and added rules for {nconcepts} existing concepts. However, couldn't add rules for {nbadconcepts} concepts.",
+            )

--- a/api/mapping/management/commands/refresh_mapping_rules.py
+++ b/api/mapping/management/commands/refresh_mapping_rules.py
@@ -8,13 +8,15 @@ from datetime import datetime
 
 
 class Command(BaseCommand):
-    help = "Refresh all the mapping rules associated to the supplied Scan Report. " \
-           "This can take a _very_ long time (hours) to execute for large numbers of " \
-           "ScanReportConcepts. It can also hang at random intervals. If this occurs " \
-           "(a single ScanReportConcept takes <2s to complete, so it's easy to spot " \
-           "when it hangs) then reboot the container, then comment out the " \
-           "'remove_mapping_rules' line below and set skip_first to skip n " \
-           "ScanReportConcepts."
+    help = (
+        "Refresh all the mapping rules associated to the supplied Scan Report. "
+        "This can take a _very_ long time (hours) to execute for large numbers of "
+        "ScanReportConcepts. It can also hang at random intervals. If this occurs "
+        "(a single ScanReportConcept takes <2s to complete, so it's easy to spot "
+        "when it hangs) then reboot the container, then comment out the "
+        "'remove_mapping_rules' line below and set skip_first to skip n "
+        "ScanReportConcepts."
+    )
 
     def add_arguments(self, parser):
         parser.add_argument("--report-id", required=True, type=int)

--- a/api/mapping/services_rules.py
+++ b/api/mapping/services_rules.py
@@ -860,7 +860,8 @@ def find_existing_scan_report_concepts(request, table_id):
     values = (
         ScanReportValue.objects.all()
         .filter(scan_report_field__scan_report_table__scan_report=table_id)
-        .filter(concepts__isnull=False).distinct()
+        .filter(concepts__isnull=False)
+        .distinct()
         .order_by("id")
     )
 
@@ -869,7 +870,8 @@ def find_existing_scan_report_concepts(request, table_id):
     fields = (
         ScanReportField.objects.all()
         .filter(scan_report_table__scan_report=table_id)
-        .filter(concepts__isnull=False).distinct()
+        .filter(concepts__isnull=False)
+        .distinct()
         .order_by("id")
     )
 

--- a/api/mapping/services_rules.py
+++ b/api/mapping/services_rules.py
@@ -860,7 +860,8 @@ def find_existing_scan_report_concepts(request, table_id):
     values = (
         ScanReportValue.objects.all()
         .filter(scan_report_field__scan_report_table__scan_report=table_id)
-        .filter(concepts__isnull=False)
+        .filter(concepts__isnull=False).distinct()
+        .order_by("id")
     )
 
     # find ScanReportField associated to this table_id
@@ -868,7 +869,8 @@ def find_existing_scan_report_concepts(request, table_id):
     fields = (
         ScanReportField.objects.all()
         .filter(scan_report_table__scan_report=table_id)
-        .filter(concepts__isnull=False)
+        .filter(concepts__isnull=False).distinct()
+        .order_by("id")
     )
 
     # retrieve all value concepts

--- a/changelog.md
+++ b/changelog.md
@@ -2,12 +2,14 @@
 
 Please append a line to the changelog for each change made.
 
-## v2.0.13
+## v2.0.13-dev
 ### New features
+- Added refresh_mapping_rules management command.
 
 ### Improvements 
-- Updated storybook to 6.4.9, removing a number of vulnerabilities.
+
 ### Bugfixes
+- Bug fixed in `find_existing_scan_report_concepts()` which was causing some `SRConcepts` to be processed multiple times. This didn't cause any issues, but was misleading and wasteful.
 
 
 ## v2.0.12


### PR DESCRIPTION
# Changes

- Added new management command `refresh_mapping_rules`.
- Bug fixed in `find_existing_scan_report_concepts()` which was causing some `SRConcepts` to be processed multiple times. This didn't cause any issues, but was misleading and wasteful.

# Migrations

NA

# Screenshots

NA

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
