### PR TITLE
Disable sr list stats

### DIFF
--- a/api/mapping/views.py
+++ b/api/mapping/views.py
@@ -308,109 +308,124 @@ class ScanReportListViewSet(viewsets.ModelViewSet):
         if self.request.user.username == os.getenv("AZ_FUNCTION_USER"):
             return ScanReport.objects.all().distinct()
 
-        return ScanReport.objects.filter(
+        f = ScanReport.objects.filter(
             # parent dataset and SR are public checks
-            Q(
-                # parent dataset and SR are public
-                parent_dataset__visibility=VisibilityChoices.PUBLIC,
-                visibility=VisibilityChoices.PUBLIC,
+            (Q(parent_dataset__visibility=VisibilityChoices.PUBLIC)
+            & (
+                Q(
+                    # parent dataset and SR are public
+                    # parent_dataset__visibility=VisibilityChoices.PUBLIC,
+                    visibility=VisibilityChoices.PUBLIC,
+                )
+                # parent dataset is public but SR restricted checks
+                | (
+                    Q(visibility=VisibilityChoices.RESTRICTED)
+                    & (
+                        Q(
+                            # parent dataset is public
+                            # SR is restricted and user is in SR viewers
+                            # parent_dataset__visibility=VisibilityChoices.PUBLIC,
+                            viewers=self.request.user.id,
+                            # visibility=VisibilityChoices.RESTRICTED,
+                        )
+                        | Q(
+                            # parent dataset is public
+                            # SR is restricted and user is in SR editors
+                            # parent_dataset__visibility=VisibilityChoices.PUBLIC,
+                            editors=self.request.user.id,
+                            # visibility=VisibilityChoices.RESTRICTED,
+                        )
+                        | Q(
+                            # parent dataset is public
+                            # SR is restricted and user is SR author
+                            # parent_dataset__visibility=VisibilityChoices.PUBLIC,
+                            author=self.request.user.id,
+                            # visibility=VisibilityChoices.RESTRICTED,
+                        )
+                        | Q(
+                            # parent dataset is public
+                            # SR is restricted and user is in parent dataset editors
+                            # parent_dataset__visibility=VisibilityChoices.PUBLIC,
+                            parent_dataset__editors=self.request.user.id,
+                            # visibility=VisibilityChoices.RESTRICTED,
+                        )
+                        | Q(
+                            # parent dataset is public
+                            # SR is restricted and user is in parent dataset admins
+                            # parent_dataset__visibility=VisibilityChoices.PUBLIC,
+                            parent_dataset__admins=self.request.user.id,
+                            # visibility=VisibilityChoices.RESTRICTED,
+                        )
+                    )
+                )
             )
-            # parent dataset is public but SR restricted checks
-            | Q(
-                # parent dataset is public
-                # SR is restricted and user is in SR viewers
-                parent_dataset__visibility=VisibilityChoices.PUBLIC,
-                viewers=self.request.user.id,
-                visibility=VisibilityChoices.RESTRICTED,
-            )
-            | Q(
-                # parent dataset is public
-                # SR is restricted and user is in SR editors
-                parent_dataset__visibility=VisibilityChoices.PUBLIC,
-                editors=self.request.user.id,
-                visibility=VisibilityChoices.RESTRICTED,
-            )
-            | Q(
-                # parent dataset is public
-                # SR is restricted and user is SR author
-                parent_dataset__visibility=VisibilityChoices.PUBLIC,
-                author=self.request.user.id,
-                visibility=VisibilityChoices.RESTRICTED,
-            )
-            | Q(
-                # parent dataset is public
-                # SR is restricted and user is in parent dataset editors
-                parent_dataset__visibility=VisibilityChoices.PUBLIC,
-                parent_dataset__editors=self.request.user.id,
-                visibility=VisibilityChoices.RESTRICTED,
-            )
-            | Q(
-                # parent dataset is public
-                # SR is restricted and user is in parent dataset admins
-                parent_dataset__visibility=VisibilityChoices.PUBLIC,
-                parent_dataset__admins=self.request.user.id,
-                visibility=VisibilityChoices.RESTRICTED,
-            )
+             )
             # parent dataset and SR are restricted checks
-            | Q(
-                # parent dataset and SR are restricted
-                # user is in SR viewers
-                parent_dataset__visibility=VisibilityChoices.RESTRICTED,
-                viewers=self.request.user.id,
-                visibility=VisibilityChoices.RESTRICTED,
+            | (Q(
+                parent_dataset__visibility=VisibilityChoices.RESTRICTED
             )
-            | Q(
-                # parent dataset and SR are restricted
-                # user is in SR editors
-                parent_dataset__visibility=VisibilityChoices.RESTRICTED,
-                editors=self.request.user.id,
-                visibility=VisibilityChoices.RESTRICTED,
-            )
-            | Q(
-                # parent dataset and SR are restricted
-                # user is SR author
-                parent_dataset__visibility=VisibilityChoices.RESTRICTED,
-                author=self.request.user.id,
-                visibility=VisibilityChoices.RESTRICTED,
-            )
-            | Q(
-                # parent dataset and SR are restricted
-                # user is in parent dataset admins
-                parent_dataset__visibility=VisibilityChoices.RESTRICTED,
-                parent_dataset__admins=self.request.user.id,
-                visibility=VisibilityChoices.RESTRICTED,
-            )
-            | Q(
-                # parent dataset and SR are restricted
-                # user is in parent dataset editors
-                parent_dataset__visibility=VisibilityChoices.RESTRICTED,
-                parent_dataset__editors=self.request.user.id,
-                visibility=VisibilityChoices.RESTRICTED,
-            )
-            # parent dataset is restricted but SR is public checks
-            | Q(
-                # parent dataset is restricted and SR public
-                # user is in parent dataset editors
-                parent_dataset__visibility=VisibilityChoices.RESTRICTED,
-                parent_dataset__editors=self.request.user.id,
-                visibility=VisibilityChoices.PUBLIC,
-            )
-            | Q(
-                # parent dataset is restricted and SR public
-                # user is in parent dataset admins
-                parent_dataset__visibility=VisibilityChoices.RESTRICTED,
-                parent_dataset__admins=self.request.user.id,
-                visibility=VisibilityChoices.PUBLIC,
-            )
-            | Q(
-                # parent dataset is restricted and SR public
-                # user is in parent dataset viewers
-                parent_dataset__visibility=VisibilityChoices.RESTRICTED,
-                parent_dataset__viewers=self.request.user.id,
-                visibility=VisibilityChoices.PUBLIC,
+            & (
+                Q(
+                    # parent_dataset__visibility=VisibilityChoices.RESTRICTED,
+                    viewers=self.request.user.id,
+                    # visibility=VisibilityChoices.RESTRICTED,
+                )
+                | Q(
+                    # parent dataset and SR are restricted
+                    # user is in SR editors
+                    # parent_dataset__visibility=VisibilityChoices.RESTRICTED,
+                    editors=self.request.user.id,
+                    # visibility=VisibilityChoices.RESTRICTED,
+                )
+                | Q(
+                    # parent dataset and SR are restricted
+                    # user is SR author
+                    # parent_dataset__visibility=VisibilityChoices.RESTRICTED,
+                    author=self.request.user.id,
+                    # visibility=VisibilityChoices.RESTRICTED,
+                )
+                | Q(
+                    # parent dataset and SR are restricted
+                    # user is in parent dataset admins
+                    # parent_dataset__visibility=VisibilityChoices.RESTRICTED,
+                    parent_dataset__admins=self.request.user.id,
+                    # visibility=VisibilityChoices.RESTRICTED,
+                )
+                | Q(
+                    # parent dataset and SR are restricted
+                    # user is in parent dataset editors
+                    # parent_dataset__visibility=VisibilityChoices.RESTRICTED,
+                    parent_dataset__editors=self.request.user.id,
+                    # visibility=VisibilityChoices.RESTRICTED,
+                )
+                # parent dataset is restricted but SR is public checks
+                | Q(
+                    # parent dataset is restricted and SR public
+                    # user is in parent dataset editors
+                    # parent_dataset__visibility=VisibilityChoices.RESTRICTED,
+                    # parent_dataset__editors=self.request.user.id,
+                    visibility=VisibilityChoices.PUBLIC,
+                )
+                # | Q(
+                #     # parent dataset is restricted and SR public
+                #     # user is in parent dataset admins
+                #     # parent_dataset__visibility=VisibilityChoices.RESTRICTED,
+                #     # parent_dataset__admins=self.request.user.id,
+                #     # visibility=VisibilityChoices.PUBLIC,
+                # )
+                # | Q(
+                #     # parent dataset is restricted and SR public
+                #     # user is in parent dataset viewers
+                #     # parent_dataset__visibility=VisibilityChoices.RESTRICTED,
+                #     # parent_dataset__viewers=self.request.user.id,
+                #     # visibility=VisibilityChoices.PUBLIC,
+                # )
+               )
             ),
             parent_dataset__project__members=self.request.user.id,
         ).distinct()
+        print(f.query)
+        return f
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(
@@ -1038,18 +1053,10 @@ class CountStatsScanReport(APIView):
         )
         jsonrecords = []
         for scanreport in parameterlist:
-            scanreporttable_count = ScanReportTable.objects.filter(
-                scan_report=scanreport
-            ).count()
-            scanreportfield_count = ScanReportField.objects.filter(
-                scan_report_table__scan_report=scanreport
-            ).count()
-            scanreportvalue_count = ScanReportValue.objects.filter(
-                scan_report_field__scan_report_table__scan_report=scanreport
-            ).count()
-            scanreportmappingrule_count = MappingRule.objects.filter(
-                scan_report=scanreport
-            ).count()
+            scanreporttable_count = "Disabled"
+            scanreportfield_count = "Disabled"
+            scanreportvalue_count = "Disabled"
+            scanreportmappingrule_count = "Disabled"
 
             scanreport_content = {
                 "scanreport": scanreport,

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ Please append a line to the changelog for each change made.
 - Added refresh_mapping_rules management command.
 
 ### Improvements 
+- Disabled stats counting on the ScanReport main page. This should improve the stability of the system, as those counts were tying up the server for 45 seconds or more.
 
 ### Bugfixes
 - Bug fixed in `find_existing_scan_report_concepts()` which was causing some `SRConcepts` to be processed multiple times. This didn't cause any issues, but was misleading and wasteful.


### PR DESCRIPTION
# Changes

- Disable the stats counting in the right-hand columns of the ScanReport list page. These were causing problems, and taking 45s+ to return results, destabilising the whole platform. For now, these just return "Disabled" text instead. The functionality was always a convenience function, and would be better implemented with regularly scheduled recalculation rather than on-the-fly computation.
- Rework the filter for the SR list API call. This is a little easier to read and (potentially) more stream-lined.

# Migrations

NA

# Screenshots

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
