### PR TITLE
Docs/135771 Add developer quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
 ### Table of Contents
 1. [Introduction](#introduction)
 1. [Getting Started](#getting-started)
-   1. [Docker](#docker)
-   1. [Manually](#manually)
-   1. [Refreshing](#refreshing) 
-1. [Pages](#pages)
-   1. [Admin](#admin)
-   1. [Home](#home)
 1. [Custom Styling](#custom-styling)
    1. [CSS](#css)
    2. [JavaScript](#javascript)
@@ -18,40 +12,7 @@ datasets to the OMOP standard through manual and automated means.
 
 # Getting Started <a name="getting-started"></a>
 
-## Docker
-
-Copy `Teams Software Team -> files -> env files -> env` to the root of project and rename it to `.env`. Ensure that it 
-contains all the variables from `sample-env.txt` from the repository. Then run the commands below.
-
-```bash
-#build the docker image, and tag it
-#make sure you include . at the end of the command
-docker build --tag <docker_image>:<tag> .
-
-# run the app
-docker run -it --volume $PWD/api:/api --env-file .env -p 8080:8000 <docker_image>
-
-```
-
-## Manually
-To run the mapping pipeline Django MVP:
-
-1.	Clone this repository
-2.	Create a Python virtual environment and install Django
-3.	Create a new superuser for testing
-4. Log into the admin area at localhost:8080/admin/ to view the data
-
-# Pages
-
-:warning: If you run manually the port is `8000`. Using the docker container, port `8000` (in the container) is forwarded to `8080` (local)
-
-## Admin 
-Point to [http://127.0.0.1:8080/admin/](http://127.0.0.1:8080/admin/) to access the django admin.
-
-
-## Home
-To access the homescreen, go to
-[http://localhost:8080/](http://localhost:8080/)
+See the Developer Quickstart at the [CaRROT documentation](https://hdruk.github.io/CaRROT-Docs/CaRROT-Mapper/quickstart-webapp/).
 
 # Custom Styling <a name="custom-styling"></a>
 

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -11,6 +11,9 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 
 import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/api/mapping/fixtures/mapping.json
+++ b/api/mapping/fixtures/mapping.json
@@ -1,0 +1,4423 @@
+[
+  {
+    "model": "mapping.omoptable",
+    "pk": 1673,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.724Z",
+      "updated_at": "2021-04-09T15:08:58.724Z",
+      "table": "condition_occurrence"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1674,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.782Z",
+      "updated_at": "2021-04-09T15:08:58.782Z",
+      "table": "death"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1675,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.811Z",
+      "updated_at": "2021-04-09T15:08:58.811Z",
+      "table": "device_exposure"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1676,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.866Z",
+      "updated_at": "2021-04-09T15:08:58.866Z",
+      "table": "drug_exposure"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1677,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.945Z",
+      "updated_at": "2021-04-09T15:08:58.945Z",
+      "table": "fact_relationship"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1678,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.966Z",
+      "updated_at": "2021-04-09T15:08:58.966Z",
+      "table": "measurement"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1679,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.042Z",
+      "updated_at": "2021-04-09T15:08:59.042Z",
+      "table": "note"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1680,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.100Z",
+      "updated_at": "2021-04-09T15:08:59.100Z",
+      "table": "note_nlp"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1681,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.152Z",
+      "updated_at": "2021-04-09T15:08:59.152Z",
+      "table": "observation"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1682,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.214Z",
+      "updated_at": "2021-04-09T15:08:59.214Z",
+      "table": "observation_period"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1683,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.233Z",
+      "updated_at": "2021-04-09T15:08:59.233Z",
+      "table": "person"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1684,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.300Z",
+      "updated_at": "2021-04-09T15:08:59.300Z",
+      "table": "procedure_occurrence"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1685,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.359Z",
+      "updated_at": "2021-04-09T15:08:59.359Z",
+      "table": "specimen"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1686,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.410Z",
+      "updated_at": "2021-04-09T15:08:59.410Z",
+      "table": "visit_detail"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1687,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.478Z",
+      "updated_at": "2021-04-09T15:08:59.479Z",
+      "table": "visit_occurrence"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1688,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.536Z",
+      "updated_at": "2021-04-09T15:08:59.536Z",
+      "table": "cohort"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1689,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.551Z",
+      "updated_at": "2021-04-09T15:08:59.551Z",
+      "table": "cohort_attribute"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1690,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.580Z",
+      "updated_at": "2021-04-09T15:08:59.580Z",
+      "table": "condition_era"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1691,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.604Z",
+      "updated_at": "2021-04-09T15:08:59.604Z",
+      "table": "dose_era"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1692,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.632Z",
+      "updated_at": "2021-04-09T15:08:59.632Z",
+      "table": "drug_era"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1693,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.658Z",
+      "updated_at": "2021-04-09T15:08:59.658Z",
+      "table": "cost"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1694,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.740Z",
+      "updated_at": "2021-04-09T15:08:59.740Z",
+      "table": "payer_plan_period"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1695,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.801Z",
+      "updated_at": "2021-04-09T15:08:59.801Z",
+      "table": "care_site"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1696,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.826Z",
+      "updated_at": "2021-04-09T15:08:59.826Z",
+      "table": "location"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1697,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.856Z",
+      "updated_at": "2021-04-09T15:08:59.856Z",
+      "table": "provider"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1698,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.903Z",
+      "updated_at": "2021-04-09T15:08:59.903Z",
+      "table": "cdm_source"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1699,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.947Z",
+      "updated_at": "2021-04-09T15:08:59.947Z",
+      "table": "metadata"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1700,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.982Z",
+      "updated_at": "2021-04-09T15:08:59.982Z",
+      "table": "attribute_definition"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1701,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.002Z",
+      "updated_at": "2021-04-09T15:09:00.002Z",
+      "table": "cohort_definition"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1702,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.038Z",
+      "updated_at": "2021-04-09T15:09:00.038Z",
+      "table": "concept"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1703,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.076Z",
+      "updated_at": "2021-04-09T15:09:00.076Z",
+      "table": "concept_ancestor"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1704,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.092Z",
+      "updated_at": "2021-04-09T15:09:00.092Z",
+      "table": "concept_class"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1705,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.111Z",
+      "updated_at": "2021-04-09T15:09:00.111Z",
+      "table": "concept_relationship"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1706,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.144Z",
+      "updated_at": "2021-04-09T15:09:00.144Z",
+      "table": "concept_synonym"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1707,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.158Z",
+      "updated_at": "2021-04-09T15:09:00.158Z",
+      "table": "domain"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1708,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.171Z",
+      "updated_at": "2021-04-09T15:09:00.171Z",
+      "table": "drug_strength"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1709,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.214Z",
+      "updated_at": "2021-04-09T15:09:00.214Z",
+      "table": "relationship"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1710,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.237Z",
+      "updated_at": "2021-04-09T15:09:00.237Z",
+      "table": "source_to_concept_map"
+    }
+  },
+  {
+    "model": "mapping.omoptable",
+    "pk": 1711,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.270Z",
+      "updated_at": "2021-04-09T15:09:00.270Z",
+      "table": "vocabulary"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 449,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.728Z",
+      "updated_at": "2021-04-09T15:08:58.728Z",
+      "table": 1673,
+      "field": "condition_occurrence_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 450,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.732Z",
+      "updated_at": "2021-04-09T15:08:58.732Z",
+      "table": 1673,
+      "field": "person_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 451,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.735Z",
+      "updated_at": "2021-04-09T15:08:58.735Z",
+      "table": 1673,
+      "field": "condition_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 452,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.738Z",
+      "updated_at": "2021-04-09T15:08:58.738Z",
+      "table": 1673,
+      "field": "condition_start_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 453,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.740Z",
+      "updated_at": "2021-04-09T15:08:58.741Z",
+      "table": 1673,
+      "field": "condition_start_datetime"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 454,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.744Z",
+      "updated_at": "2021-04-09T15:08:58.744Z",
+      "table": 1673,
+      "field": "condition_end_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 455,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.747Z",
+      "updated_at": "2021-04-09T15:08:58.747Z",
+      "table": 1673,
+      "field": "condition_end_datetime"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 456,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.749Z",
+      "updated_at": "2021-04-09T15:08:58.749Z",
+      "table": 1673,
+      "field": "condition_type_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 457,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.752Z",
+      "updated_at": "2021-04-09T15:08:58.752Z",
+      "table": 1673,
+      "field": "stop_reason"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 458,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.755Z",
+      "updated_at": "2021-04-09T15:08:58.755Z",
+      "table": 1673,
+      "field": "provider_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 459,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.762Z",
+      "updated_at": "2021-04-09T15:08:58.762Z",
+      "table": 1673,
+      "field": "visit_occurrence_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 460,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.765Z",
+      "updated_at": "2021-04-09T15:08:58.765Z",
+      "table": 1673,
+      "field": "visit_detail_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 461,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.769Z",
+      "updated_at": "2021-04-09T15:08:58.769Z",
+      "table": 1673,
+      "field": "condition_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 462,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.772Z",
+      "updated_at": "2021-04-09T15:08:58.772Z",
+      "table": 1673,
+      "field": "condition_source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 463,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.775Z",
+      "updated_at": "2021-04-09T15:08:58.775Z",
+      "table": 1673,
+      "field": "condition_status_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 464,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.779Z",
+      "updated_at": "2021-04-09T15:08:58.779Z",
+      "table": 1673,
+      "field": "condition_status_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 465,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.785Z",
+      "updated_at": "2021-04-09T15:08:58.785Z",
+      "table": 1674,
+      "field": "person_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 466,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.788Z",
+      "updated_at": "2021-04-09T15:08:58.788Z",
+      "table": 1674,
+      "field": "death_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 467,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.791Z",
+      "updated_at": "2021-04-09T15:08:58.791Z",
+      "table": 1674,
+      "field": "death_datetime"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 468,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.798Z",
+      "updated_at": "2021-04-09T15:08:58.798Z",
+      "table": 1674,
+      "field": "death_type_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 469,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.801Z",
+      "updated_at": "2021-04-09T15:08:58.801Z",
+      "table": 1674,
+      "field": "cause_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 470,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.804Z",
+      "updated_at": "2021-04-09T15:08:58.804Z",
+      "table": 1674,
+      "field": "cause_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 471,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.807Z",
+      "updated_at": "2021-04-09T15:08:58.807Z",
+      "table": 1674,
+      "field": "cause_source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 472,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.815Z",
+      "updated_at": "2021-04-09T15:08:58.815Z",
+      "table": 1675,
+      "field": "device_exposure_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 473,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.819Z",
+      "updated_at": "2021-04-09T15:08:58.819Z",
+      "table": 1675,
+      "field": "person_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 474,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.823Z",
+      "updated_at": "2021-04-09T15:08:58.823Z",
+      "table": 1675,
+      "field": "device_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 475,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.826Z",
+      "updated_at": "2021-04-09T15:08:58.826Z",
+      "table": 1675,
+      "field": "device_exposure_start_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 476,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.828Z",
+      "updated_at": "2021-04-09T15:08:58.828Z",
+      "table": 1675,
+      "field": "device_exposure_start_datetime"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 477,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.834Z",
+      "updated_at": "2021-04-09T15:08:58.834Z",
+      "table": 1675,
+      "field": "device_exposure_end_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 478,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.837Z",
+      "updated_at": "2021-04-09T15:08:58.837Z",
+      "table": 1675,
+      "field": "device_exposure_end_datetime"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 479,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.840Z",
+      "updated_at": "2021-04-09T15:08:58.840Z",
+      "table": 1675,
+      "field": "device_type_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 480,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.843Z",
+      "updated_at": "2021-04-09T15:08:58.843Z",
+      "table": 1675,
+      "field": "unique_device_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 481,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.847Z",
+      "updated_at": "2021-04-09T15:08:58.847Z",
+      "table": 1675,
+      "field": "quantity"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 482,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.850Z",
+      "updated_at": "2021-04-09T15:08:58.850Z",
+      "table": 1675,
+      "field": "provider_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 483,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.853Z",
+      "updated_at": "2021-04-09T15:08:58.853Z",
+      "table": 1675,
+      "field": "visit_occurrence_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 484,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.856Z",
+      "updated_at": "2021-04-09T15:08:58.856Z",
+      "table": 1675,
+      "field": "visit_detail_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 485,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.859Z",
+      "updated_at": "2021-04-09T15:08:58.859Z",
+      "table": 1675,
+      "field": "device_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 486,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.862Z",
+      "updated_at": "2021-04-09T15:08:58.862Z",
+      "table": 1675,
+      "field": "device_source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 487,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.870Z",
+      "updated_at": "2021-04-09T15:08:58.870Z",
+      "table": 1676,
+      "field": "drug_exposure_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 488,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.873Z",
+      "updated_at": "2021-04-09T15:08:58.873Z",
+      "table": 1676,
+      "field": "person_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 489,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.876Z",
+      "updated_at": "2021-04-09T15:08:58.876Z",
+      "table": 1676,
+      "field": "drug_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 490,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.879Z",
+      "updated_at": "2021-04-09T15:08:58.879Z",
+      "table": 1676,
+      "field": "drug_exposure_start_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 491,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.882Z",
+      "updated_at": "2021-04-09T15:08:58.882Z",
+      "table": 1676,
+      "field": "drug_exposure_start_datetime"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 492,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.886Z",
+      "updated_at": "2021-04-09T15:08:58.886Z",
+      "table": 1676,
+      "field": "drug_exposure_end_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 493,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.889Z",
+      "updated_at": "2021-04-09T15:08:58.889Z",
+      "table": 1676,
+      "field": "drug_exposure_end_datetime"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 494,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.892Z",
+      "updated_at": "2021-04-09T15:08:58.892Z",
+      "table": 1676,
+      "field": "verbatim_end_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 495,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.895Z",
+      "updated_at": "2021-04-09T15:08:58.895Z",
+      "table": 1676,
+      "field": "drug_type_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 496,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.898Z",
+      "updated_at": "2021-04-09T15:08:58.898Z",
+      "table": 1676,
+      "field": "stop_reason"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 497,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.902Z",
+      "updated_at": "2021-04-09T15:08:58.902Z",
+      "table": 1676,
+      "field": "refills"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 498,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.905Z",
+      "updated_at": "2021-04-09T15:08:58.905Z",
+      "table": 1676,
+      "field": "quantity"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 499,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.908Z",
+      "updated_at": "2021-04-09T15:08:58.908Z",
+      "table": 1676,
+      "field": "days_supply"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 500,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.911Z",
+      "updated_at": "2021-04-09T15:08:58.911Z",
+      "table": 1676,
+      "field": "sig"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 501,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.914Z",
+      "updated_at": "2021-04-09T15:08:58.914Z",
+      "table": 1676,
+      "field": "route_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 502,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.917Z",
+      "updated_at": "2021-04-09T15:08:58.917Z",
+      "table": 1676,
+      "field": "lot_number"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 503,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.921Z",
+      "updated_at": "2021-04-09T15:08:58.921Z",
+      "table": 1676,
+      "field": "provider_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 504,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.924Z",
+      "updated_at": "2021-04-09T15:08:58.924Z",
+      "table": 1676,
+      "field": "visit_occurrence_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 505,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.927Z",
+      "updated_at": "2021-04-09T15:08:58.927Z",
+      "table": 1676,
+      "field": "visit_detail_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 506,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.931Z",
+      "updated_at": "2021-04-09T15:08:58.931Z",
+      "table": 1676,
+      "field": "drug_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 507,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.934Z",
+      "updated_at": "2021-04-09T15:08:58.934Z",
+      "table": 1676,
+      "field": "drug_source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 508,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.938Z",
+      "updated_at": "2021-04-09T15:08:58.938Z",
+      "table": 1676,
+      "field": "route_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 509,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.941Z",
+      "updated_at": "2021-04-09T15:08:58.941Z",
+      "table": 1676,
+      "field": "dose_unit_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 510,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.949Z",
+      "updated_at": "2021-04-09T15:08:58.949Z",
+      "table": 1677,
+      "field": "domain_concept_id_1"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 511,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.952Z",
+      "updated_at": "2021-04-09T15:08:58.952Z",
+      "table": 1677,
+      "field": "fact_id_1"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 512,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.956Z",
+      "updated_at": "2021-04-09T15:08:58.956Z",
+      "table": 1677,
+      "field": "domain_concept_id_2"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 513,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.959Z",
+      "updated_at": "2021-04-09T15:08:58.960Z",
+      "table": 1677,
+      "field": "fact_id_2"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 514,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.963Z",
+      "updated_at": "2021-04-09T15:08:58.963Z",
+      "table": 1677,
+      "field": "relationship_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 515,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.970Z",
+      "updated_at": "2021-04-09T15:08:58.970Z",
+      "table": 1678,
+      "field": "measurement_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 516,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.973Z",
+      "updated_at": "2021-04-09T15:08:58.973Z",
+      "table": 1678,
+      "field": "person_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 517,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.979Z",
+      "updated_at": "2021-04-09T15:08:58.979Z",
+      "table": 1678,
+      "field": "measurement_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 518,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.982Z",
+      "updated_at": "2021-04-09T15:08:58.982Z",
+      "table": 1678,
+      "field": "measurement_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 519,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.985Z",
+      "updated_at": "2021-04-09T15:08:58.985Z",
+      "table": 1678,
+      "field": "measurement_datetime"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 520,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.990Z",
+      "updated_at": "2021-04-09T15:08:58.990Z",
+      "table": 1678,
+      "field": "measurement_time"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 521,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.994Z",
+      "updated_at": "2021-04-09T15:08:58.994Z",
+      "table": 1678,
+      "field": "measurement_type_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 522,
+    "fields": {
+      "created_at": "2021-04-09T15:08:58.997Z",
+      "updated_at": "2021-04-09T15:08:58.997Z",
+      "table": 1678,
+      "field": "operator_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 523,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.001Z",
+      "updated_at": "2021-04-09T15:08:59.001Z",
+      "table": 1678,
+      "field": "value_as_number"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 524,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.004Z",
+      "updated_at": "2021-04-09T15:08:59.004Z",
+      "table": 1678,
+      "field": "value_as_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 525,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.007Z",
+      "updated_at": "2021-04-09T15:08:59.007Z",
+      "table": 1678,
+      "field": "unit_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 526,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.010Z",
+      "updated_at": "2021-04-09T15:08:59.010Z",
+      "table": 1678,
+      "field": "range_low"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 527,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.014Z",
+      "updated_at": "2021-04-09T15:08:59.014Z",
+      "table": 1678,
+      "field": "range_high"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 528,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.018Z",
+      "updated_at": "2021-04-09T15:08:59.018Z",
+      "table": 1678,
+      "field": "provider_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 529,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.021Z",
+      "updated_at": "2021-04-09T15:08:59.021Z",
+      "table": 1678,
+      "field": "visit_occurrence_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 530,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.024Z",
+      "updated_at": "2021-04-09T15:08:59.024Z",
+      "table": 1678,
+      "field": "visit_detail_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 531,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.027Z",
+      "updated_at": "2021-04-09T15:08:59.027Z",
+      "table": 1678,
+      "field": "measurement_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 532,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.031Z",
+      "updated_at": "2021-04-09T15:08:59.031Z",
+      "table": 1678,
+      "field": "measurement_source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 533,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.035Z",
+      "updated_at": "2021-04-09T15:08:59.035Z",
+      "table": 1678,
+      "field": "unit_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 534,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.039Z",
+      "updated_at": "2021-04-09T15:08:59.039Z",
+      "table": 1678,
+      "field": "value_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 535,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.046Z",
+      "updated_at": "2021-04-09T15:08:59.046Z",
+      "table": 1679,
+      "field": "note_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 536,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.049Z",
+      "updated_at": "2021-04-09T15:08:59.049Z",
+      "table": 1679,
+      "field": "person_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 537,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.052Z",
+      "updated_at": "2021-04-09T15:08:59.052Z",
+      "table": 1679,
+      "field": "note_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 538,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.056Z",
+      "updated_at": "2021-04-09T15:08:59.056Z",
+      "table": 1679,
+      "field": "note_datetime"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 539,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.063Z",
+      "updated_at": "2021-04-09T15:08:59.063Z",
+      "table": 1679,
+      "field": "note_type_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 540,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.067Z",
+      "updated_at": "2021-04-09T15:08:59.067Z",
+      "table": 1679,
+      "field": "note_class_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 541,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.071Z",
+      "updated_at": "2021-04-09T15:08:59.071Z",
+      "table": 1679,
+      "field": "note_title"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 542,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.073Z",
+      "updated_at": "2021-04-09T15:08:59.073Z",
+      "table": 1679,
+      "field": "note_text"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 543,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.077Z",
+      "updated_at": "2021-04-09T15:08:59.077Z",
+      "table": 1679,
+      "field": "encoding_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 544,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.080Z",
+      "updated_at": "2021-04-09T15:08:59.080Z",
+      "table": 1679,
+      "field": "language_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 545,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.084Z",
+      "updated_at": "2021-04-09T15:08:59.084Z",
+      "table": 1679,
+      "field": "provider_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 546,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.087Z",
+      "updated_at": "2021-04-09T15:08:59.087Z",
+      "table": 1679,
+      "field": "visit_occurrence_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 547,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.092Z",
+      "updated_at": "2021-04-09T15:08:59.092Z",
+      "table": 1679,
+      "field": "visit_detail_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 548,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.097Z",
+      "updated_at": "2021-04-09T15:08:59.097Z",
+      "table": 1679,
+      "field": "note_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 549,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.104Z",
+      "updated_at": "2021-04-09T15:08:59.104Z",
+      "table": 1680,
+      "field": "yes"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 550,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.109Z",
+      "updated_at": "2021-04-09T15:08:59.109Z",
+      "table": 1680,
+      "field": "yes"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 551,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.112Z",
+      "updated_at": "2021-04-09T15:08:59.112Z",
+      "table": 1680,
+      "field": "no"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 552,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.115Z",
+      "updated_at": "2021-04-09T15:08:59.115Z",
+      "table": 1680,
+      "field": "no"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 553,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.118Z",
+      "updated_at": "2021-04-09T15:08:59.118Z",
+      "table": 1680,
+      "field": "no"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 554,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.121Z",
+      "updated_at": "2021-04-09T15:08:59.121Z",
+      "table": 1680,
+      "field": "yes"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 555,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.124Z",
+      "updated_at": "2021-04-09T15:08:59.124Z",
+      "table": 1680,
+      "field": "no"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 556,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.127Z",
+      "updated_at": "2021-04-09T15:08:59.127Z",
+      "table": 1680,
+      "field": "no"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 557,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.130Z",
+      "updated_at": "2021-04-09T15:08:59.130Z",
+      "table": 1680,
+      "field": "no"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 558,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.133Z",
+      "updated_at": "2021-04-09T15:08:59.133Z",
+      "table": 1680,
+      "field": "yes"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 559,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.137Z",
+      "updated_at": "2021-04-09T15:08:59.137Z",
+      "table": 1680,
+      "field": "no"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 560,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.142Z",
+      "updated_at": "2021-04-09T15:08:59.142Z",
+      "table": 1680,
+      "field": "no"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 561,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.145Z",
+      "updated_at": "2021-04-09T15:08:59.145Z",
+      "table": 1680,
+      "field": "no"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 562,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.149Z",
+      "updated_at": "2021-04-09T15:08:59.149Z",
+      "table": 1680,
+      "field": "no"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 563,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.156Z",
+      "updated_at": "2021-04-09T15:08:59.156Z",
+      "table": 1681,
+      "field": "observation_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 564,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.159Z",
+      "updated_at": "2021-04-09T15:08:59.160Z",
+      "table": 1681,
+      "field": "person_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 565,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.163Z",
+      "updated_at": "2021-04-09T15:08:59.163Z",
+      "table": 1681,
+      "field": "observation_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 566,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.166Z",
+      "updated_at": "2021-04-09T15:08:59.166Z",
+      "table": 1681,
+      "field": "observation_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 567,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.170Z",
+      "updated_at": "2021-04-09T15:08:59.170Z",
+      "table": 1681,
+      "field": "observation_datetime"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 568,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.173Z",
+      "updated_at": "2021-04-09T15:08:59.173Z",
+      "table": 1681,
+      "field": "observation_type_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 569,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.176Z",
+      "updated_at": "2021-04-09T15:08:59.176Z",
+      "table": 1681,
+      "field": "value_as_number"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 570,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.179Z",
+      "updated_at": "2021-04-09T15:08:59.179Z",
+      "table": 1681,
+      "field": "value_as_string"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 571,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.182Z",
+      "updated_at": "2021-04-09T15:08:59.182Z",
+      "table": 1681,
+      "field": "value_as_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 572,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.185Z",
+      "updated_at": "2021-04-09T15:08:59.185Z",
+      "table": 1681,
+      "field": "qualifier_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 573,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.188Z",
+      "updated_at": "2021-04-09T15:08:59.188Z",
+      "table": 1681,
+      "field": "unit_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 574,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.192Z",
+      "updated_at": "2021-04-09T15:08:59.192Z",
+      "table": 1681,
+      "field": "provider_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 575,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.194Z",
+      "updated_at": "2021-04-09T15:08:59.194Z",
+      "table": 1681,
+      "field": "visit_occurrence_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 576,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.197Z",
+      "updated_at": "2021-04-09T15:08:59.197Z",
+      "table": 1681,
+      "field": "visit_detail_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 577,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.201Z",
+      "updated_at": "2021-04-09T15:08:59.201Z",
+      "table": 1681,
+      "field": "observation_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 578,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.204Z",
+      "updated_at": "2021-04-09T15:08:59.204Z",
+      "table": 1681,
+      "field": "observation_source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 579,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.207Z",
+      "updated_at": "2021-04-09T15:08:59.207Z",
+      "table": 1681,
+      "field": "unit_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 580,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.211Z",
+      "updated_at": "2021-04-09T15:08:59.211Z",
+      "table": 1681,
+      "field": "qualifier_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 581,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.217Z",
+      "updated_at": "2021-04-09T15:08:59.218Z",
+      "table": 1682,
+      "field": "observation_period_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 582,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.221Z",
+      "updated_at": "2021-04-09T15:08:59.221Z",
+      "table": 1682,
+      "field": "person_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 583,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.224Z",
+      "updated_at": "2021-04-09T15:08:59.224Z",
+      "table": 1682,
+      "field": "observation_period_start_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 584,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.227Z",
+      "updated_at": "2021-04-09T15:08:59.227Z",
+      "table": 1682,
+      "field": "observation_period_end_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 585,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.230Z",
+      "updated_at": "2021-04-09T15:08:59.230Z",
+      "table": 1682,
+      "field": "period_type_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 586,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.238Z",
+      "updated_at": "2021-04-09T15:08:59.238Z",
+      "table": 1683,
+      "field": "person_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 587,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.241Z",
+      "updated_at": "2021-04-09T15:08:59.241Z",
+      "table": 1683,
+      "field": "gender_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 588,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.244Z",
+      "updated_at": "2021-04-09T15:08:59.244Z",
+      "table": 1683,
+      "field": "year_of_birth"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 589,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.249Z",
+      "updated_at": "2021-04-09T15:08:59.249Z",
+      "table": 1683,
+      "field": "month_of_birth"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 590,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.252Z",
+      "updated_at": "2021-04-09T15:08:59.252Z",
+      "table": 1683,
+      "field": "day_of_birth"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 591,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.255Z",
+      "updated_at": "2021-04-09T15:08:59.255Z",
+      "table": 1683,
+      "field": "birth_datetime"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 592,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.258Z",
+      "updated_at": "2021-04-09T15:08:59.258Z",
+      "table": 1683,
+      "field": "race_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 593,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.261Z",
+      "updated_at": "2021-04-09T15:08:59.261Z",
+      "table": 1683,
+      "field": "ethnicity_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 594,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.268Z",
+      "updated_at": "2021-04-09T15:08:59.268Z",
+      "table": 1683,
+      "field": "location_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 595,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.272Z",
+      "updated_at": "2021-04-09T15:08:59.272Z",
+      "table": 1683,
+      "field": "provider_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 596,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.275Z",
+      "updated_at": "2021-04-09T15:08:59.275Z",
+      "table": 1683,
+      "field": "care_site_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 597,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.279Z",
+      "updated_at": "2021-04-09T15:08:59.279Z",
+      "table": 1683,
+      "field": "person_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 598,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.282Z",
+      "updated_at": "2021-04-09T15:08:59.282Z",
+      "table": 1683,
+      "field": "gender_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 599,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.285Z",
+      "updated_at": "2021-04-09T15:08:59.285Z",
+      "table": 1683,
+      "field": "gender_source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 600,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.288Z",
+      "updated_at": "2021-04-09T15:08:59.288Z",
+      "table": 1683,
+      "field": "race_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 601,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.291Z",
+      "updated_at": "2021-04-09T15:08:59.291Z",
+      "table": 1683,
+      "field": "race_source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 602,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.294Z",
+      "updated_at": "2021-04-09T15:08:59.294Z",
+      "table": 1683,
+      "field": "ethnicity_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 603,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.297Z",
+      "updated_at": "2021-04-09T15:08:59.297Z",
+      "table": 1683,
+      "field": "ethnicity_source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 604,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.304Z",
+      "updated_at": "2021-04-09T15:08:59.304Z",
+      "table": 1684,
+      "field": "procedure_occurrence_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 605,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.308Z",
+      "updated_at": "2021-04-09T15:08:59.308Z",
+      "table": 1684,
+      "field": "person_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 606,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.311Z",
+      "updated_at": "2021-04-09T15:08:59.311Z",
+      "table": 1684,
+      "field": "procedure_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 607,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.313Z",
+      "updated_at": "2021-04-09T15:08:59.313Z",
+      "table": 1684,
+      "field": "procedure_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 608,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.316Z",
+      "updated_at": "2021-04-09T15:08:59.317Z",
+      "table": 1684,
+      "field": "procedure_datetime"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 609,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.321Z",
+      "updated_at": "2021-04-09T15:08:59.321Z",
+      "table": 1684,
+      "field": "procedure_type_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 610,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.325Z",
+      "updated_at": "2021-04-09T15:08:59.325Z",
+      "table": 1684,
+      "field": "modifier_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 611,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.328Z",
+      "updated_at": "2021-04-09T15:08:59.328Z",
+      "table": 1684,
+      "field": "quantity"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 612,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.331Z",
+      "updated_at": "2021-04-09T15:08:59.331Z",
+      "table": 1684,
+      "field": "provider_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 613,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.339Z",
+      "updated_at": "2021-04-09T15:08:59.339Z",
+      "table": 1684,
+      "field": "visit_occurrence_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 614,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.342Z",
+      "updated_at": "2021-04-09T15:08:59.342Z",
+      "table": 1684,
+      "field": "visit_detail_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 615,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.345Z",
+      "updated_at": "2021-04-09T15:08:59.345Z",
+      "table": 1684,
+      "field": "procedure_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 616,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.349Z",
+      "updated_at": "2021-04-09T15:08:59.349Z",
+      "table": 1684,
+      "field": "procedure_source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 617,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.354Z",
+      "updated_at": "2021-04-09T15:08:59.354Z",
+      "table": 1684,
+      "field": "modifier_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 618,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.363Z",
+      "updated_at": "2021-04-09T15:08:59.363Z",
+      "table": 1685,
+      "field": "specimen_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 619,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.367Z",
+      "updated_at": "2021-04-09T15:08:59.367Z",
+      "table": 1685,
+      "field": "person_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 620,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.370Z",
+      "updated_at": "2021-04-09T15:08:59.370Z",
+      "table": 1685,
+      "field": "specimen_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 621,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.373Z",
+      "updated_at": "2021-04-09T15:08:59.373Z",
+      "table": 1685,
+      "field": "specimen_type_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 622,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.375Z",
+      "updated_at": "2021-04-09T15:08:59.375Z",
+      "table": 1685,
+      "field": "specimen_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 623,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.378Z",
+      "updated_at": "2021-04-09T15:08:59.378Z",
+      "table": 1685,
+      "field": "specimen_datetime"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 624,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.382Z",
+      "updated_at": "2021-04-09T15:08:59.382Z",
+      "table": 1685,
+      "field": "quantity"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 625,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.385Z",
+      "updated_at": "2021-04-09T15:08:59.385Z",
+      "table": 1685,
+      "field": "unit_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 626,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.389Z",
+      "updated_at": "2021-04-09T15:08:59.389Z",
+      "table": 1685,
+      "field": "anatomic_site_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 627,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.392Z",
+      "updated_at": "2021-04-09T15:08:59.392Z",
+      "table": 1685,
+      "field": "disease_status_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 628,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.395Z",
+      "updated_at": "2021-04-09T15:08:59.395Z",
+      "table": 1685,
+      "field": "specimen_source_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 629,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.398Z",
+      "updated_at": "2021-04-09T15:08:59.398Z",
+      "table": 1685,
+      "field": "specimen_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 630,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.402Z",
+      "updated_at": "2021-04-09T15:08:59.402Z",
+      "table": 1685,
+      "field": "unit_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 631,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.404Z",
+      "updated_at": "2021-04-09T15:08:59.404Z",
+      "table": 1685,
+      "field": "anatomic_site_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 632,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.408Z",
+      "updated_at": "2021-04-09T15:08:59.408Z",
+      "table": 1685,
+      "field": "disease_status_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 633,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.415Z",
+      "updated_at": "2021-04-09T15:08:59.415Z",
+      "table": 1686,
+      "field": "visit_detail_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 634,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.419Z",
+      "updated_at": "2021-04-09T15:08:59.419Z",
+      "table": 1686,
+      "field": "person_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 635,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.424Z",
+      "updated_at": "2021-04-09T15:08:59.424Z",
+      "table": 1686,
+      "field": "visit_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 636,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.427Z",
+      "updated_at": "2021-04-09T15:08:59.427Z",
+      "table": 1686,
+      "field": "visit_start_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 637,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.431Z",
+      "updated_at": "2021-04-09T15:08:59.431Z",
+      "table": 1686,
+      "field": "visit_start_datetime"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 638,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.434Z",
+      "updated_at": "2021-04-09T15:08:59.434Z",
+      "table": 1686,
+      "field": "visit_end_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 639,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.437Z",
+      "updated_at": "2021-04-09T15:08:59.437Z",
+      "table": 1686,
+      "field": "visit_end_datetime"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 640,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.440Z",
+      "updated_at": "2021-04-09T15:08:59.440Z",
+      "table": 1686,
+      "field": "visit_type_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 641,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.443Z",
+      "updated_at": "2021-04-09T15:08:59.443Z",
+      "table": 1686,
+      "field": "provider_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 642,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.446Z",
+      "updated_at": "2021-04-09T15:08:59.446Z",
+      "table": 1686,
+      "field": "care_site_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 643,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.449Z",
+      "updated_at": "2021-04-09T15:08:59.449Z",
+      "table": 1686,
+      "field": "visit_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 644,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.452Z",
+      "updated_at": "2021-04-09T15:08:59.452Z",
+      "table": 1686,
+      "field": "visit_source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 645,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.455Z",
+      "updated_at": "2021-04-09T15:08:59.455Z",
+      "table": 1686,
+      "field": "admitting_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 646,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.458Z",
+      "updated_at": "2021-04-09T15:08:59.458Z",
+      "table": 1686,
+      "field": "admitting_source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 647,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.461Z",
+      "updated_at": "2021-04-09T15:08:59.461Z",
+      "table": 1686,
+      "field": "discharge_to_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 648,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.463Z",
+      "updated_at": "2021-04-09T15:08:59.463Z",
+      "table": 1686,
+      "field": "discharge_to_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 649,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.469Z",
+      "updated_at": "2021-04-09T15:08:59.469Z",
+      "table": 1686,
+      "field": "preceding_visit_detail_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 650,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.472Z",
+      "updated_at": "2021-04-09T15:08:59.472Z",
+      "table": 1686,
+      "field": "visit_detail_parent_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 651,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.475Z",
+      "updated_at": "2021-04-09T15:08:59.475Z",
+      "table": 1686,
+      "field": "visit_occurrence_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 652,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.483Z",
+      "updated_at": "2021-04-09T15:08:59.483Z",
+      "table": 1687,
+      "field": "visit_occurrence_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 653,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.486Z",
+      "updated_at": "2021-04-09T15:08:59.486Z",
+      "table": 1687,
+      "field": "person_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 654,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.489Z",
+      "updated_at": "2021-04-09T15:08:59.489Z",
+      "table": 1687,
+      "field": "visit_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 655,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.492Z",
+      "updated_at": "2021-04-09T15:08:59.492Z",
+      "table": 1687,
+      "field": "visit_start_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 656,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.496Z",
+      "updated_at": "2021-04-09T15:08:59.496Z",
+      "table": 1687,
+      "field": "visit_start_datetime"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 657,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.498Z",
+      "updated_at": "2021-04-09T15:08:59.498Z",
+      "table": 1687,
+      "field": "visit_end_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 658,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.501Z",
+      "updated_at": "2021-04-09T15:08:59.501Z",
+      "table": 1687,
+      "field": "visit_end_datetime"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 659,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.504Z",
+      "updated_at": "2021-04-09T15:08:59.504Z",
+      "table": 1687,
+      "field": "visit_type_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 660,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.507Z",
+      "updated_at": "2021-04-09T15:08:59.507Z",
+      "table": 1687,
+      "field": "provider_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 661,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.510Z",
+      "updated_at": "2021-04-09T15:08:59.510Z",
+      "table": 1687,
+      "field": "care_site_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 662,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.513Z",
+      "updated_at": "2021-04-09T15:08:59.513Z",
+      "table": 1687,
+      "field": "visit_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 663,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.516Z",
+      "updated_at": "2021-04-09T15:08:59.516Z",
+      "table": 1687,
+      "field": "visit_source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 664,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.519Z",
+      "updated_at": "2021-04-09T15:08:59.519Z",
+      "table": 1687,
+      "field": "admitting_source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 665,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.523Z",
+      "updated_at": "2021-04-09T15:08:59.523Z",
+      "table": 1687,
+      "field": "admitting_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 666,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.526Z",
+      "updated_at": "2021-04-09T15:08:59.526Z",
+      "table": 1687,
+      "field": "discharge_to_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 667,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.530Z",
+      "updated_at": "2021-04-09T15:08:59.530Z",
+      "table": 1687,
+      "field": "discharge_to_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 668,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.533Z",
+      "updated_at": "2021-04-09T15:08:59.533Z",
+      "table": 1687,
+      "field": "preceding_visit_occurrence_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 669,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.539Z",
+      "updated_at": "2021-04-09T15:08:59.539Z",
+      "table": 1688,
+      "field": "cohort_definition_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 670,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.543Z",
+      "updated_at": "2021-04-09T15:08:59.543Z",
+      "table": 1688,
+      "field": "subject_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 671,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.546Z",
+      "updated_at": "2021-04-09T15:08:59.546Z",
+      "table": 1688,
+      "field": "cohort_start_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 672,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.549Z",
+      "updated_at": "2021-04-09T15:08:59.549Z",
+      "table": 1688,
+      "field": "cohort_end_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 673,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.555Z",
+      "updated_at": "2021-04-09T15:08:59.555Z",
+      "table": 1689,
+      "field": "cohort_definition_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 674,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.558Z",
+      "updated_at": "2021-04-09T15:08:59.558Z",
+      "table": 1689,
+      "field": "subject_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 675,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.561Z",
+      "updated_at": "2021-04-09T15:08:59.561Z",
+      "table": 1689,
+      "field": "cohort_start_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 676,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.564Z",
+      "updated_at": "2021-04-09T15:08:59.564Z",
+      "table": 1689,
+      "field": "cohort_end_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 677,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.568Z",
+      "updated_at": "2021-04-09T15:08:59.568Z",
+      "table": 1689,
+      "field": "attribute_definition_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 678,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.571Z",
+      "updated_at": "2021-04-09T15:08:59.571Z",
+      "table": 1689,
+      "field": "value_as_number"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 679,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.575Z",
+      "updated_at": "2021-04-09T15:08:59.575Z",
+      "table": 1689,
+      "field": "value_as_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 680,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.584Z",
+      "updated_at": "2021-04-09T15:08:59.584Z",
+      "table": 1690,
+      "field": "condition_era_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 681,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.587Z",
+      "updated_at": "2021-04-09T15:08:59.587Z",
+      "table": 1690,
+      "field": "person_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 682,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.590Z",
+      "updated_at": "2021-04-09T15:08:59.590Z",
+      "table": 1690,
+      "field": "condition_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 683,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.593Z",
+      "updated_at": "2021-04-09T15:08:59.593Z",
+      "table": 1690,
+      "field": "condition_era_start_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 684,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.597Z",
+      "updated_at": "2021-04-09T15:08:59.597Z",
+      "table": 1690,
+      "field": "condition_era_end_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 685,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.600Z",
+      "updated_at": "2021-04-09T15:08:59.600Z",
+      "table": 1690,
+      "field": "condition_occurrence_count"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 686,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.609Z",
+      "updated_at": "2021-04-09T15:08:59.609Z",
+      "table": 1691,
+      "field": "dose_era_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 687,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.612Z",
+      "updated_at": "2021-04-09T15:08:59.612Z",
+      "table": 1691,
+      "field": "person_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 688,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.616Z",
+      "updated_at": "2021-04-09T15:08:59.616Z",
+      "table": 1691,
+      "field": "drug_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 689,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.619Z",
+      "updated_at": "2021-04-09T15:08:59.619Z",
+      "table": 1691,
+      "field": "unit_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 690,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.622Z",
+      "updated_at": "2021-04-09T15:08:59.622Z",
+      "table": 1691,
+      "field": "dose_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 691,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.625Z",
+      "updated_at": "2021-04-09T15:08:59.626Z",
+      "table": 1691,
+      "field": "dose_era_start_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 692,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.628Z",
+      "updated_at": "2021-04-09T15:08:59.628Z",
+      "table": 1691,
+      "field": "dose_era_end_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 693,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.636Z",
+      "updated_at": "2021-04-09T15:08:59.636Z",
+      "table": 1692,
+      "field": "drug_era_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 694,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.639Z",
+      "updated_at": "2021-04-09T15:08:59.639Z",
+      "table": 1692,
+      "field": "person_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 695,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.643Z",
+      "updated_at": "2021-04-09T15:08:59.643Z",
+      "table": 1692,
+      "field": "drug_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 696,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.646Z",
+      "updated_at": "2021-04-09T15:08:59.646Z",
+      "table": 1692,
+      "field": "drug_era_start_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 697,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.649Z",
+      "updated_at": "2021-04-09T15:08:59.649Z",
+      "table": 1692,
+      "field": "drug_era_end_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 698,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.652Z",
+      "updated_at": "2021-04-09T15:08:59.652Z",
+      "table": 1692,
+      "field": "drug_exposure_count"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 699,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.655Z",
+      "updated_at": "2021-04-09T15:08:59.655Z",
+      "table": 1692,
+      "field": "gap_days"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 700,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.661Z",
+      "updated_at": "2021-04-09T15:08:59.661Z",
+      "table": 1693,
+      "field": "cost_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 701,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.665Z",
+      "updated_at": "2021-04-09T15:08:59.665Z",
+      "table": 1693,
+      "field": "cost_event_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 702,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.668Z",
+      "updated_at": "2021-04-09T15:08:59.668Z",
+      "table": 1693,
+      "field": "cost_domain_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 703,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.672Z",
+      "updated_at": "2021-04-09T15:08:59.672Z",
+      "table": 1693,
+      "field": "cost_type_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 704,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.675Z",
+      "updated_at": "2021-04-09T15:08:59.675Z",
+      "table": 1693,
+      "field": "currency_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 705,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.678Z",
+      "updated_at": "2021-04-09T15:08:59.678Z",
+      "table": 1693,
+      "field": "total_charge"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 706,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.681Z",
+      "updated_at": "2021-04-09T15:08:59.681Z",
+      "table": 1693,
+      "field": "total_cost"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 707,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.684Z",
+      "updated_at": "2021-04-09T15:08:59.684Z",
+      "table": 1693,
+      "field": "total_paid"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 708,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.689Z",
+      "updated_at": "2021-04-09T15:08:59.689Z",
+      "table": 1693,
+      "field": "paid_by_payer"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 709,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.693Z",
+      "updated_at": "2021-04-09T15:08:59.693Z",
+      "table": 1693,
+      "field": "paid_by_patient"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 710,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.697Z",
+      "updated_at": "2021-04-09T15:08:59.697Z",
+      "table": 1693,
+      "field": "paid_patient_copay"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 711,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.700Z",
+      "updated_at": "2021-04-09T15:08:59.700Z",
+      "table": 1693,
+      "field": "paid_patient_coinsurance"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 712,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.703Z",
+      "updated_at": "2021-04-09T15:08:59.703Z",
+      "table": 1693,
+      "field": "paid_patient_deductible"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 713,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.706Z",
+      "updated_at": "2021-04-09T15:08:59.706Z",
+      "table": 1693,
+      "field": "paid_by_primary"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 714,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.713Z",
+      "updated_at": "2021-04-09T15:08:59.713Z",
+      "table": 1693,
+      "field": "paid_ingredient_cost"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 715,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.715Z",
+      "updated_at": "2021-04-09T15:08:59.715Z",
+      "table": 1693,
+      "field": "paid_dispensing_fee"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 716,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.719Z",
+      "updated_at": "2021-04-09T15:08:59.719Z",
+      "table": 1693,
+      "field": "payer_plan_period_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 717,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.722Z",
+      "updated_at": "2021-04-09T15:08:59.722Z",
+      "table": 1693,
+      "field": "amount_allowed"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 718,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.726Z",
+      "updated_at": "2021-04-09T15:08:59.726Z",
+      "table": 1693,
+      "field": "revenue_code_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 719,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.729Z",
+      "updated_at": "2021-04-09T15:08:59.729Z",
+      "table": 1693,
+      "field": "revenue_code_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 720,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.732Z",
+      "updated_at": "2021-04-09T15:08:59.732Z",
+      "table": 1693,
+      "field": "drg_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 721,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.737Z",
+      "updated_at": "2021-04-09T15:08:59.737Z",
+      "table": 1693,
+      "field": "drg_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 722,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.743Z",
+      "updated_at": "2021-04-09T15:08:59.743Z",
+      "table": 1694,
+      "field": "payer_plan_period_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 723,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.746Z",
+      "updated_at": "2021-04-09T15:08:59.746Z",
+      "table": 1694,
+      "field": "person_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 724,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.750Z",
+      "updated_at": "2021-04-09T15:08:59.750Z",
+      "table": 1694,
+      "field": "payer_plan_period_start_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 725,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.754Z",
+      "updated_at": "2021-04-09T15:08:59.754Z",
+      "table": 1694,
+      "field": "payer_plan_period_end_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 726,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.757Z",
+      "updated_at": "2021-04-09T15:08:59.757Z",
+      "table": 1694,
+      "field": "payer_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 727,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.760Z",
+      "updated_at": "2021-04-09T15:08:59.760Z",
+      "table": 1694,
+      "field": "payer_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 728,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.764Z",
+      "updated_at": "2021-04-09T15:08:59.764Z",
+      "table": 1694,
+      "field": "payer_source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 729,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.767Z",
+      "updated_at": "2021-04-09T15:08:59.767Z",
+      "table": 1694,
+      "field": "plan_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 730,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.770Z",
+      "updated_at": "2021-04-09T15:08:59.770Z",
+      "table": 1694,
+      "field": "plan_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 731,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.774Z",
+      "updated_at": "2021-04-09T15:08:59.774Z",
+      "table": 1694,
+      "field": "plan_source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 732,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.777Z",
+      "updated_at": "2021-04-09T15:08:59.777Z",
+      "table": 1694,
+      "field": "sponsor_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 733,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.781Z",
+      "updated_at": "2021-04-09T15:08:59.781Z",
+      "table": 1694,
+      "field": "sponsor_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 734,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.784Z",
+      "updated_at": "2021-04-09T15:08:59.784Z",
+      "table": 1694,
+      "field": "sponsor_source_concept_id*"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 735,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.787Z",
+      "updated_at": "2021-04-09T15:08:59.787Z",
+      "table": 1694,
+      "field": "family_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 736,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.790Z",
+      "updated_at": "2021-04-09T15:08:59.790Z",
+      "table": 1694,
+      "field": "stop_reason_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 737,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.793Z",
+      "updated_at": "2021-04-09T15:08:59.793Z",
+      "table": 1694,
+      "field": "stop_reason_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 738,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.798Z",
+      "updated_at": "2021-04-09T15:08:59.798Z",
+      "table": 1694,
+      "field": "stop_reason_source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 739,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.805Z",
+      "updated_at": "2021-04-09T15:08:59.805Z",
+      "table": 1695,
+      "field": "care_site_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 740,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.808Z",
+      "updated_at": "2021-04-09T15:08:59.808Z",
+      "table": 1695,
+      "field": "care_site_name"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 741,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.811Z",
+      "updated_at": "2021-04-09T15:08:59.811Z",
+      "table": 1695,
+      "field": "place_of_service_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 742,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.815Z",
+      "updated_at": "2021-04-09T15:08:59.815Z",
+      "table": 1695,
+      "field": "location_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 743,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.818Z",
+      "updated_at": "2021-04-09T15:08:59.818Z",
+      "table": 1695,
+      "field": "care_site_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 744,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.823Z",
+      "updated_at": "2021-04-09T15:08:59.823Z",
+      "table": 1695,
+      "field": "place_of_service_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 745,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.830Z",
+      "updated_at": "2021-04-09T15:08:59.830Z",
+      "table": 1696,
+      "field": "location_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 746,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.833Z",
+      "updated_at": "2021-04-09T15:08:59.833Z",
+      "table": 1696,
+      "field": "address_1"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 747,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.837Z",
+      "updated_at": "2021-04-09T15:08:59.837Z",
+      "table": 1696,
+      "field": "address_2"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 748,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.840Z",
+      "updated_at": "2021-04-09T15:08:59.840Z",
+      "table": 1696,
+      "field": "city"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 749,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.843Z",
+      "updated_at": "2021-04-09T15:08:59.843Z",
+      "table": 1696,
+      "field": "state"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 750,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.846Z",
+      "updated_at": "2021-04-09T15:08:59.846Z",
+      "table": 1696,
+      "field": "zip"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 751,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.849Z",
+      "updated_at": "2021-04-09T15:08:59.849Z",
+      "table": 1696,
+      "field": "county"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 752,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.853Z",
+      "updated_at": "2021-04-09T15:08:59.853Z",
+      "table": 1696,
+      "field": "location_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 753,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.859Z",
+      "updated_at": "2021-04-09T15:08:59.859Z",
+      "table": 1697,
+      "field": "provider_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 754,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.863Z",
+      "updated_at": "2021-04-09T15:08:59.863Z",
+      "table": 1697,
+      "field": "provider_name"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 755,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.866Z",
+      "updated_at": "2021-04-09T15:08:59.866Z",
+      "table": 1697,
+      "field": "npi"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 756,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.870Z",
+      "updated_at": "2021-04-09T15:08:59.870Z",
+      "table": 1697,
+      "field": "dea"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 757,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.873Z",
+      "updated_at": "2021-04-09T15:08:59.873Z",
+      "table": 1697,
+      "field": "specialty_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 758,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.876Z",
+      "updated_at": "2021-04-09T15:08:59.876Z",
+      "table": 1697,
+      "field": "care_site_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 759,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.879Z",
+      "updated_at": "2021-04-09T15:08:59.879Z",
+      "table": 1697,
+      "field": "year_of_birth"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 760,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.882Z",
+      "updated_at": "2021-04-09T15:08:59.882Z",
+      "table": 1697,
+      "field": "gender_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 761,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.885Z",
+      "updated_at": "2021-04-09T15:08:59.885Z",
+      "table": 1697,
+      "field": "provider_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 762,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.888Z",
+      "updated_at": "2021-04-09T15:08:59.888Z",
+      "table": 1697,
+      "field": "specialty_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 763,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.892Z",
+      "updated_at": "2021-04-09T15:08:59.892Z",
+      "table": 1697,
+      "field": "specialty_source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 764,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.896Z",
+      "updated_at": "2021-04-09T15:08:59.896Z",
+      "table": 1697,
+      "field": "gender_source_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 765,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.899Z",
+      "updated_at": "2021-04-09T15:08:59.899Z",
+      "table": 1697,
+      "field": "gender_source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 766,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.913Z",
+      "updated_at": "2021-04-09T15:08:59.913Z",
+      "table": 1698,
+      "field": "cdm_source_name"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 767,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.916Z",
+      "updated_at": "2021-04-09T15:08:59.916Z",
+      "table": 1698,
+      "field": "cdm_source_abbreviation"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 768,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.919Z",
+      "updated_at": "2021-04-09T15:08:59.919Z",
+      "table": 1698,
+      "field": "cdm_holder"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 769,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.923Z",
+      "updated_at": "2021-04-09T15:08:59.923Z",
+      "table": 1698,
+      "field": "source_description"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 770,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.926Z",
+      "updated_at": "2021-04-09T15:08:59.926Z",
+      "table": 1698,
+      "field": "source_documentation_reference"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 771,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.930Z",
+      "updated_at": "2021-04-09T15:08:59.930Z",
+      "table": 1698,
+      "field": "cdm_etl_reference"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 772,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.933Z",
+      "updated_at": "2021-04-09T15:08:59.933Z",
+      "table": 1698,
+      "field": "source_release_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 773,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.937Z",
+      "updated_at": "2021-04-09T15:08:59.937Z",
+      "table": 1698,
+      "field": "cdm_release_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 774,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.940Z",
+      "updated_at": "2021-04-09T15:08:59.940Z",
+      "table": 1698,
+      "field": "cdm_version"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 775,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.943Z",
+      "updated_at": "2021-04-09T15:08:59.943Z",
+      "table": 1698,
+      "field": "vocabulary_version"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 776,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.952Z",
+      "updated_at": "2021-04-09T15:08:59.952Z",
+      "table": 1699,
+      "field": "metadata_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 777,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.959Z",
+      "updated_at": "2021-04-09T15:08:59.959Z",
+      "table": 1699,
+      "field": "metadata_type_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 778,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.963Z",
+      "updated_at": "2021-04-09T15:08:59.963Z",
+      "table": 1699,
+      "field": "name"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 779,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.966Z",
+      "updated_at": "2021-04-09T15:08:59.966Z",
+      "table": 1699,
+      "field": "value_as_string"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 780,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.970Z",
+      "updated_at": "2021-04-09T15:08:59.970Z",
+      "table": 1699,
+      "field": "value_as_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 781,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.973Z",
+      "updated_at": "2021-04-09T15:08:59.973Z",
+      "table": 1699,
+      "field": "metadata date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 782,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.978Z",
+      "updated_at": "2021-04-09T15:08:59.978Z",
+      "table": 1699,
+      "field": "metadata_datetime"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 783,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.986Z",
+      "updated_at": "2021-04-09T15:08:59.986Z",
+      "table": 1700,
+      "field": "attribute_definition_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 784,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.989Z",
+      "updated_at": "2021-04-09T15:08:59.989Z",
+      "table": 1700,
+      "field": "attribute_name"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 785,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.993Z",
+      "updated_at": "2021-04-09T15:08:59.993Z",
+      "table": 1700,
+      "field": "attribute_description"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 786,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.996Z",
+      "updated_at": "2021-04-09T15:08:59.996Z",
+      "table": 1700,
+      "field": "attribute_type_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 787,
+    "fields": {
+      "created_at": "2021-04-09T15:08:59.999Z",
+      "updated_at": "2021-04-09T15:08:59.999Z",
+      "table": 1700,
+      "field": "attribute_syntax"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 788,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.009Z",
+      "updated_at": "2021-04-09T15:09:00.009Z",
+      "table": 1701,
+      "field": "cohort_definition_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 789,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.013Z",
+      "updated_at": "2021-04-09T15:09:00.013Z",
+      "table": 1701,
+      "field": "cohort_definition_name"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 790,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.017Z",
+      "updated_at": "2021-04-09T15:09:00.017Z",
+      "table": 1701,
+      "field": "cohort_definition_description"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 791,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.023Z",
+      "updated_at": "2021-04-09T15:09:00.023Z",
+      "table": 1701,
+      "field": "definition_type_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 792,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.026Z",
+      "updated_at": "2021-04-09T15:09:00.026Z",
+      "table": 1701,
+      "field": "cohort_definition_syntax"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 793,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.032Z",
+      "updated_at": "2021-04-09T15:09:00.032Z",
+      "table": 1701,
+      "field": "subject_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 794,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.035Z",
+      "updated_at": "2021-04-09T15:09:00.035Z",
+      "table": 1701,
+      "field": "cohort_initiation_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 795,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.043Z",
+      "updated_at": "2021-04-09T15:09:00.043Z",
+      "table": 1702,
+      "field": "concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 796,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.047Z",
+      "updated_at": "2021-04-09T15:09:00.047Z",
+      "table": 1702,
+      "field": "concept_name"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 797,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.050Z",
+      "updated_at": "2021-04-09T15:09:00.050Z",
+      "table": 1702,
+      "field": "domain_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 798,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.053Z",
+      "updated_at": "2021-04-09T15:09:00.053Z",
+      "table": 1702,
+      "field": "vocabulary_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 799,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.056Z",
+      "updated_at": "2021-04-09T15:09:00.056Z",
+      "table": 1702,
+      "field": "concept_class_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 800,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.062Z",
+      "updated_at": "2021-04-09T15:09:00.062Z",
+      "table": 1702,
+      "field": "standard_concept"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 801,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.064Z",
+      "updated_at": "2021-04-09T15:09:00.064Z",
+      "table": 1702,
+      "field": "concept_code"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 802,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.067Z",
+      "updated_at": "2021-04-09T15:09:00.067Z",
+      "table": 1702,
+      "field": "valid_start_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 803,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.070Z",
+      "updated_at": "2021-04-09T15:09:00.070Z",
+      "table": 1702,
+      "field": "valid_end_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 804,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.074Z",
+      "updated_at": "2021-04-09T15:09:00.074Z",
+      "table": 1702,
+      "field": "invalid_reason"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 805,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.079Z",
+      "updated_at": "2021-04-09T15:09:00.079Z",
+      "table": 1703,
+      "field": "ancestor_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 806,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.082Z",
+      "updated_at": "2021-04-09T15:09:00.082Z",
+      "table": 1703,
+      "field": "descendant_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 807,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.085Z",
+      "updated_at": "2021-04-09T15:09:00.085Z",
+      "table": 1703,
+      "field": "min_levels_of_separation"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 808,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.088Z",
+      "updated_at": "2021-04-09T15:09:00.088Z",
+      "table": 1703,
+      "field": "max_levels_of_separation"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 809,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.095Z",
+      "updated_at": "2021-04-09T15:09:00.095Z",
+      "table": 1704,
+      "field": "concept_class_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 810,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.105Z",
+      "updated_at": "2021-04-09T15:09:00.105Z",
+      "table": 1704,
+      "field": "concept_class_name"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 811,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.108Z",
+      "updated_at": "2021-04-09T15:09:00.108Z",
+      "table": 1704,
+      "field": "concept_class_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 812,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.115Z",
+      "updated_at": "2021-04-09T15:09:00.115Z",
+      "table": 1705,
+      "field": "concept_id_1"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 813,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.118Z",
+      "updated_at": "2021-04-09T15:09:00.118Z",
+      "table": 1705,
+      "field": "concept_id_2"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 814,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.124Z",
+      "updated_at": "2021-04-09T15:09:00.124Z",
+      "table": 1705,
+      "field": "relationship_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 815,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.134Z",
+      "updated_at": "2021-04-09T15:09:00.134Z",
+      "table": 1705,
+      "field": "valid_start_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 816,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.137Z",
+      "updated_at": "2021-04-09T15:09:00.137Z",
+      "table": 1705,
+      "field": "valid_end_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 817,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.141Z",
+      "updated_at": "2021-04-09T15:09:00.141Z",
+      "table": 1705,
+      "field": "invalid_reason"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 818,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.149Z",
+      "updated_at": "2021-04-09T15:09:00.149Z",
+      "table": 1706,
+      "field": "concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 819,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.152Z",
+      "updated_at": "2021-04-09T15:09:00.152Z",
+      "table": 1706,
+      "field": "concept_synonym_name"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 820,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.155Z",
+      "updated_at": "2021-04-09T15:09:00.155Z",
+      "table": 1706,
+      "field": "language_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 821,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.161Z",
+      "updated_at": "2021-04-09T15:09:00.161Z",
+      "table": 1707,
+      "field": "domain_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 822,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.164Z",
+      "updated_at": "2021-04-09T15:09:00.164Z",
+      "table": 1707,
+      "field": "domain_name"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 823,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.168Z",
+      "updated_at": "2021-04-09T15:09:00.168Z",
+      "table": 1707,
+      "field": "domain_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 824,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.175Z",
+      "updated_at": "2021-04-09T15:09:00.175Z",
+      "table": 1708,
+      "field": "drug_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 825,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.178Z",
+      "updated_at": "2021-04-09T15:09:00.178Z",
+      "table": 1708,
+      "field": "ingredient_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 826,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.181Z",
+      "updated_at": "2021-04-09T15:09:00.181Z",
+      "table": 1708,
+      "field": "amount_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 827,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.185Z",
+      "updated_at": "2021-04-09T15:09:00.185Z",
+      "table": 1708,
+      "field": "amount_unit_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 828,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.188Z",
+      "updated_at": "2021-04-09T15:09:00.188Z",
+      "table": 1708,
+      "field": "numerator_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 829,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.191Z",
+      "updated_at": "2021-04-09T15:09:00.191Z",
+      "table": 1708,
+      "field": "numerator_unit_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 830,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.194Z",
+      "updated_at": "2021-04-09T15:09:00.194Z",
+      "table": 1708,
+      "field": "denominator_value"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 831,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.198Z",
+      "updated_at": "2021-04-09T15:09:00.198Z",
+      "table": 1708,
+      "field": "denominator_unit_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 832,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.201Z",
+      "updated_at": "2021-04-09T15:09:00.201Z",
+      "table": 1708,
+      "field": "box_size"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 833,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.204Z",
+      "updated_at": "2021-04-09T15:09:00.204Z",
+      "table": 1708,
+      "field": "valid_start_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 834,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.208Z",
+      "updated_at": "2021-04-09T15:09:00.208Z",
+      "table": 1708,
+      "field": "valid_end_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 835,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.211Z",
+      "updated_at": "2021-04-09T15:09:00.211Z",
+      "table": 1708,
+      "field": "invalid_reason"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 836,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.217Z",
+      "updated_at": "2021-04-09T15:09:00.217Z",
+      "table": 1709,
+      "field": "relationship_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 837,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.221Z",
+      "updated_at": "2021-04-09T15:09:00.221Z",
+      "table": 1709,
+      "field": "relationship_name"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 838,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.225Z",
+      "updated_at": "2021-04-09T15:09:00.225Z",
+      "table": 1709,
+      "field": "is_hierarchical"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 839,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.227Z",
+      "updated_at": "2021-04-09T15:09:00.227Z",
+      "table": 1709,
+      "field": "defines_ancestry"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 840,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.230Z",
+      "updated_at": "2021-04-09T15:09:00.230Z",
+      "table": 1709,
+      "field": "reverse_relationship_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 841,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.233Z",
+      "updated_at": "2021-04-09T15:09:00.233Z",
+      "table": 1709,
+      "field": "relationship_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 842,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.240Z",
+      "updated_at": "2021-04-09T15:09:00.240Z",
+      "table": 1710,
+      "field": "source_code"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 843,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.243Z",
+      "updated_at": "2021-04-09T15:09:00.243Z",
+      "table": 1710,
+      "field": "source_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 844,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.247Z",
+      "updated_at": "2021-04-09T15:09:00.247Z",
+      "table": 1710,
+      "field": "source_vocabulary_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 845,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.250Z",
+      "updated_at": "2021-04-09T15:09:00.250Z",
+      "table": 1710,
+      "field": "source_code_description"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 846,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.253Z",
+      "updated_at": "2021-04-09T15:09:00.253Z",
+      "table": 1710,
+      "field": "target_concept_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 847,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.256Z",
+      "updated_at": "2021-04-09T15:09:00.256Z",
+      "table": 1710,
+      "field": "target_vocabulary_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 848,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.259Z",
+      "updated_at": "2021-04-09T15:09:00.259Z",
+      "table": 1710,
+      "field": "valid_start_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 849,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.263Z",
+      "updated_at": "2021-04-09T15:09:00.263Z",
+      "table": 1710,
+      "field": "valid_end_date"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 850,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.267Z",
+      "updated_at": "2021-04-09T15:09:00.267Z",
+      "table": 1710,
+      "field": "invalid_reason"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 851,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.274Z",
+      "updated_at": "2021-04-09T15:09:00.274Z",
+      "table": 1711,
+      "field": "vocabulary_id"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 852,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.278Z",
+      "updated_at": "2021-04-09T15:09:00.278Z",
+      "table": 1711,
+      "field": "vocabulary_name"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 853,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.280Z",
+      "updated_at": "2021-04-09T15:09:00.280Z",
+      "table": 1711,
+      "field": "vocabulary_reference"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 854,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.283Z",
+      "updated_at": "2021-04-09T15:09:00.284Z",
+      "table": 1711,
+      "field": "vocabulary_version"
+    }
+  },
+  {
+    "model": "mapping.omopfield",
+    "pk": 855,
+    "fields": {
+      "created_at": "2021-04-09T15:09:00.287Z",
+      "updated_at": "2021-04-09T15:09:00.287Z",
+      "table": 1711,
+      "field": "vocabulary_concept_id"
+    }
+  }
+]

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -14,3 +14,4 @@ gunicorn
 graphviz
 drf-dynamic-fields
 django-cors-headers
+python-dotenv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,3 +28,6 @@ services:
       - .env
     volumes: 
       - $PWD/api:/api
+    depends_on:
+      - db
+      - azurite

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+name: carrot-mapper-dev
+
+services:
+  db:
+    image: postgres:13
+    restart: always
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_PASSWORD: postgres
+
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite
+    restart: always
+    ports:
+      - "10000:10000"
+      - "10001:10001"
+      - "10002:10002"
+  
+  web:
+    image: carrot
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 8000:8000
+    env_file:
+      - .env
+    volumes: 
+      - $PWD/api:/api

--- a/sample-env.txt
+++ b/sample-env.txt
@@ -1,16 +1,16 @@
 ALLOWED_HOSTS=['localhost']
-AZURE_ACCOUNT_NAME=ccomstoragedev
+AZURE_ACCOUNT_NAME=devstoreaccount1
 COCONNECT_DB_ENGINE=django.db.backends.postgresql
-COCONNECT_DB_HOST=
-COCONNECT_DB_NAME=
-COCONNECT_DB_PASSWORD=
+COCONNECT_DB_HOST=db
+COCONNECT_DB_NAME=postgres
+COCONNECT_DB_PASSWORD=postgres
 COCONNECT_DB_PORT=5432
-COCONNECT_DB_USER=
+COCONNECT_DB_USER=postgres
 COCONNECT_DB_AUTH_TOKEN=
 DEBUG=True
 NLP_QUEUE_NAME=nlpqueue
 SCAN_REPORT_QUEUE_NAME=scanreports
 SECRET_KEY=secret
-STORAGE_CONN_STRING=
-CCOM_APP_URL= 
+STORAGE_CONN_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;QueueEndpoint=http://azurite:10001/devstoreaccount1;"
+CCOM_APP_URL= http://localhost:8000
 

--- a/sample-env.txt
+++ b/sample-env.txt
@@ -8,8 +8,8 @@ COCONNECT_DB_PORT=5432
 COCONNECT_DB_USER=postgres
 COCONNECT_DB_AUTH_TOKEN=
 DEBUG=True
-NLP_QUEUE_NAME=nlpqueue
-SCAN_REPORT_QUEUE_NAME=scanreports
+NLP_QUEUE_NAME=nlpqueue-local
+SCAN_REPORT_QUEUE_NAME=scanreports-local
 SECRET_KEY=secret
 STORAGE_CONN_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;QueueEndpoint=http://azurite:10001/devstoreaccount1;"
 CCOM_APP_URL= http://localhost:8000

--- a/sample-local.settings.json
+++ b/sample-local.settings.json
@@ -5,7 +5,7 @@
         "FUNCTIONS_WORKER_RUNTIME":"python",
         "STORAGE_CONN_STRING":"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;QueueEndpoint=http://azurite:10001/devstoreaccount1;BlobEndpoint=http://azurite:10000/devstoreaccount1;",
         "NLP_API_KEY":"",
-        "APP_URL":"http://localhost:8080/",
+        "APP_URL":"http://localhost:8000/",
         "AZ_FUNCTION_KEY":"",
         "SCAN_REPORT_QUEUE_NAME":"scanreports-local",
         "NLP_QUEUE_NAME":"nlpqueue-local",

--- a/sample-local.settings.json
+++ b/sample-local.settings.json
@@ -1,9 +1,9 @@
 {
     "IsEncrypted":false,
     "Values": {
-        "AzureWebJobsStorage":"",
+        "AzureWebJobsStorage":"UseDevelopmentStorage=true",
         "FUNCTIONS_WORKER_RUNTIME":"python",
-        "STORAGE_CONN_STRING":"",
+        "STORAGE_CONN_STRING":"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;QueueEndpoint=http://azurite:10001/devstoreaccount1;BlobEndpoint=http://azurite:10000/devstoreaccount1;",
         "NLP_API_KEY":"",
         "APP_URL":"http://localhost:8080/",
         "AZ_FUNCTION_KEY":"",


### PR DESCRIPTION
# Changes

Adds a developer quick start to get the app running, with corresponding documentation: https://github.com/HDRUK/CaRROT-Docs/pull/17

Includes:
- Adds a `docker-compose` to get the stack running.
- Updates the `sample-env` and `sample-local-settings` to use default values that work with the docker environment.
- Adds seed data fixtures to populate the `OmopTable` and `OmopField` tables.
- Adds python-dotenv as a dependency, to enable loading configuration from environment variables on all systems.
- Updates readme to point to the docs, it doesn't feel necessary to maintain both.

# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
